### PR TITLE
handle perl requirement

### DIFF
--- a/lib/App/cpm/Distribution.pm
+++ b/lib/App/cpm/Distribution.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use App::cpm::version;
 use App::cpm::Logger;
+use CPAN::DistnameInfo;
 
 sub new {
     my ($class, %option) = @_;
@@ -23,6 +24,13 @@ for my $attr (qw(
         my $self = shift;
         $self->{$attr} = shift if @_;
         $self->{$attr};
+    };
+}
+
+sub distvname {
+    my $self = shift;
+    $self->{distvname} ||= do {
+        CPAN::DistnameInfo->new($self->distfile)->distvname || $self->distfile;
     };
 }
 

--- a/xt/14_perl_req.t
+++ b/xt/14_perl_req.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More;
+use xt::CLI;
+use Path::Tiny;
+
+subtest ng => sub {
+    my $cpanfile = Path::Tiny->tempfile;
+    $cpanfile->spew(<<___);
+requires "perl", "5.99.0";
+requires 'Plack';
+___
+    my $r = cpm_install "--cpanfile", $cpanfile->stringify;
+    isnt $r->exit, 0;
+    unlike $r->err, qr/Plack/; # do not install Plack
+};
+
+subtest ng => sub {
+    my $r = cpm_install "--target-perl", "5.8.1", "HTTP::Tinyish";
+    isnt $r->exit, 0;
+    like $r->err, qr/DONE install HTTP-Tiny-/; # install HTTP::Tiny anyway
+    unlike $r->err, qr/DONE install HTTP-Tinyish-/;
+    note $r->err;
+};
+
+done_testing;

--- a/xt/CLI.pm
+++ b/xt/CLI.pm
@@ -5,11 +5,12 @@ use utf8;
 use Capture::Tiny 'capture';
 use File::Temp 'tempdir';
 use Exporter 'import';
-use FindBin '$Bin';
+use File::Basename ();
+use File::Spec;
 use Cwd 'abs_path';
 our @EXPORT = qw(cpm_install with_same_local);
 
-my $base = abs_path("$Bin/..");
+my $base = abs_path( File::Spec->catdir(File::Basename::dirname(__FILE__), "..") );
 
 my $TEMPDIR = tempdir CLEANUP => 1;
 


### PR DESCRIPTION
Now cpm correctly handles `perl` requirements.
Eg:
```
> cpm install --target-perl 5.8.5 Mojolicious
FAIL Mojolicious-6.50 requires perl 5.010001
...

> cat cpanfile
requires "perl", "5.30.0";
requires "Plack";

> cpm install
Loading modules from cpanfile...
cpanfile requires perl 5.30.0
```