### PR TITLE
Introduce  App::cpm::Worker::Resolver::*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ perl:
   - '5.10'
   - '5.8'
 install:
-  - cpanm -nq --installdeps --with-develop .
+  - cpanm -nq --installdeps --with-develop --with-recommends .
 script:
   - prove -l t xt
 sudo: false

--- a/META.json
+++ b/META.json
@@ -44,6 +44,9 @@
          }
       },
       "runtime" : {
+         "recommends" : {
+            "Carton::Snapshot" : "0"
+         },
          "requires" : {
             "CPAN::DistnameInfo" : "0",
             "CPAN::Meta" : "0",

--- a/cpanfile
+++ b/cpanfile
@@ -23,6 +23,8 @@ requires 'Module::Build', '0.38';       # shipt with  perl v5.13.11
 requires 'ExtUtils::MakeMaker', '6.58'; # shipt with  perl v5.15.1
 requires 'ExtUtils::Install', '1.46';   # shipt after perl v5.10.1
 
+recommends 'Carton::Snapshot';
+
 on develop => sub {
     requires 'Capture::Tiny';
     requires 'Path::Tiny';

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -219,10 +219,12 @@ sub is_satisfied {
 }
 
 sub add_distribution {
-    my ($self, $distribution, $provide) = @_;
+    my ($self, $distribution, $provides) = @_;
     my $distfile = $distribution->distfile;
     if (my $already = $self->{distributions}{$distfile}) {
-        $already->append_provide($provide) if $provide;
+        if ($provides) {
+            $already->append_provide($_) for @$provides;
+        }
         return 0;
     } else {
         $self->{distributions}{$distfile} = $distribution;
@@ -258,9 +260,9 @@ sub _register_resolve_result {
 
     my $distribution = App::cpm::Distribution->new(
         distfile => $job->{distfile},
-        provides => [$job->{provide}],
+        provides => $job->{provides},
     );
-    $self->add_distribution($distribution, $job->{provide});
+    $self->add_distribution($distribution, $job->{provides});
 }
 
 sub _register_fetch_result {

--- a/lib/App/cpm/Worker.pm
+++ b/lib/App/cpm/Worker.pm
@@ -44,7 +44,7 @@ sub info {
     my $distvname = CPAN::DistnameInfo->new($job->{distfile})->distvname || $job->{distfile};
     my $message;
     if ($type eq "resolve") {
-        $message = $job->{package} . ($job->{ok} ? " -> $distvname" : "");
+        $message = $job->{package} . ($job->{ok} ? " -> $distvname (from $job->{from})" : "");
     } else {
         $message = $distvname;
     }

--- a/lib/App/cpm/Worker/Resolver.pm
+++ b/lib/App/cpm/Worker/Resolver.pm
@@ -1,43 +1,39 @@
 package App::cpm::Worker::Resolver;
 use strict;
 use warnings;
-use utf8;
 
-use HTTP::Tiny;
-use CPAN::Meta::YAML;
-use App::cpm::version;
-use App::cpm::Logger;
+sub _load_class {
+    my $module = shift;
+    eval "require $module; 1;" or die $@;
+}
 
 sub new {
     my ($class, %option) = @_;
-    my $ua = HTTP::Tiny->new(timeout => 15, keep_alive => 1);
-    bless { %option, ua => $ua }, $class;
+
+    my @backends;
+    for my $r (@{$option{resolver}}) {
+        my $klass;
+        if ($r->{cpanmetadb}) {
+            $klass = "App::cpm::Worker::Resolver::MetaDB";
+        } elsif ($r->{snapshot}) {
+            $klass = "App::cpm::Worker::Resolver::Snapshot";
+        } else {
+            die "Unknown option";
+        }
+        _load_class $klass;
+        push @backends, $klass->new(%$r);
+    }
+    bless { backends => \@backends }, $class;
 }
 
 sub work {
     my ($self, $job) = @_;
-    my $res = $self->{ua}->get( "$self->{cpanmetadb}/$job->{package}" );
-    if ($res->{success}) {
-        my $yaml = CPAN::Meta::YAML->read_string($res->{content});
-        my $meta = $yaml->[0];
-        my $version = $meta->{version} eq "undef" ? 0 : $meta->{version};
-        if (my $req_version = $job->{version}) {
-            unless (App::cpm::version->parse($version)->satisfy($req_version)) {
-                App::cpm::Logger->log(
-                    result => "WARN",
-                    message => "Couldn't find $job->{package} $req_version (only found $version)",
-                );
-                return { ok => 0 };
-            }
-        }
-        return {
-            ok => 1,
-            distfile => $meta->{distfile},
-            version => $meta->{version},
-            provide => +{package => $job->{package}, version => $version},
-        };
+    my $res;
+    for my $backend (@{$self->{backends}}) {
+        $res = $backend->work($job);
+        return $res if $res->{ok};
     }
-    return { ok => 0 };
+    $res;
 }
 
 1;

--- a/lib/App/cpm/Worker/Resolver/MetaDB.pm
+++ b/lib/App/cpm/Worker/Resolver/MetaDB.pm
@@ -1,0 +1,50 @@
+package App::cpm::Worker::Resolver::MetaDB;
+use strict;
+use warnings;
+use utf8;
+
+use HTTP::Tiny;
+use CPAN::Meta::YAML;
+use App::cpm::version;
+use App::cpm::Logger;
+
+sub new {
+    my ($class, %option) = @_;
+    my $ua = HTTP::Tiny->new(timeout => 15, keep_alive => 1);
+    bless { %option, ua => $ua }, $class;
+}
+
+sub work {
+    my ($self, $job) = @_;
+    my $res = $self->{ua}->get( "$self->{cpanmetadb}/$job->{package}" );
+    if ($res->{success}) {
+        my $yaml = CPAN::Meta::YAML->read_string($res->{content});
+        my $meta = $yaml->[0];
+        my $version = $meta->{version} eq "undef" ? 0 : $meta->{version};
+        if (my $req_version = $job->{version}) {
+            if (!App::cpm::version->parse($version)->satisfy($req_version)) {
+                App::cpm::Logger->log(
+                    result => "WARN",
+                    message => "Couldn't find $job->{package} $req_version (only found $version)",
+                );
+                return { ok => 0 };
+            }
+        }
+        my @provides = map {
+            my $package = $_;
+            my $version = $meta->{provides}{$_};
+            $version = undef if $version eq "undef";
+            +{ package => $package, version => $version };
+        } sort keys %{$meta->{provides}};
+        return {
+            ok => 1,
+            distfile => $meta->{distfile},
+            version  => $meta->{version},
+            provides => \@provides,
+            from => "cpanmetadb",
+        };
+    }
+    return { ok => 0 };
+}
+
+1;

--- a/lib/App/cpm/Worker/Resolver/Snapshot.pm
+++ b/lib/App/cpm/Worker/Resolver/Snapshot.pm
@@ -1,0 +1,50 @@
+package App::cpm::Worker::Resolver::Snapshot;
+use strict;
+use warnings;
+use App::cpm::version;
+use App::cpm::Logger;
+use Carton::Snapshot;
+
+sub new {
+    my ($class, %option) = @_;
+    my $snapshot = Carton::Snapshot->new(path => $option{snapshot} || "cpanfile.snapshot");
+    $snapshot->load;
+    bless { snapshot => $snapshot }, $class;
+}
+
+sub snapshot { shift->{snapshot} }
+
+sub work {
+    my ($self, $job) = @_;
+    my $package = $job->{package};
+    my $found = $self->snapshot->find($package);
+    return { ok => 0 } unless $found;
+
+    my $version = $found->version_for($package);
+    if (my $req_version = $job->{version}) {
+        if (!App::cpm::version->parse($version)->satisfy($req_version)) {
+            App::cpm::Logger->log(
+                result => "WARN",
+                message => "Couldn't find $job->{package} $req_version (only found $version)",
+            );
+            return { ok => 0 };
+        }
+    }
+
+    my @provides = map {
+        my $package = $_;
+        my $version = $found->provides->{$_}{version};
+        $version = undef if $version eq "undef";
+        +{ package => $package, version => $version };
+    } sort keys %{$found->provides};
+
+    return {
+        ok => 1,
+        distfile => $found->distfile,
+        version  => $version,
+        provides => \@provides,
+        from => "snapshot",
+    };
+}
+
+1;

--- a/xt/03_resolver.t
+++ b/xt/03_resolver.t
@@ -5,7 +5,9 @@ use Test::More;
 use App::cpm::Worker::Resolver;
 
 my $r = App::cpm::Worker::Resolver->new(
-    cpanmetadb => "http://cpanmetadb.plackperl.org/v1.0/package",
+    resolver => [
+        {cpanmetadb => "http://cpanmetadb.plackperl.org/v1.0/package"},
+    ],
 );
 
 my $res = $r->work(+{ package => "Plack", version => 1 });

--- a/xt/15_snapshot.t
+++ b/xt/15_snapshot.t
@@ -1,0 +1,59 @@
+use strict;
+use warnings;
+use Test::More;
+use xt::CLI;
+use Path::Tiny;
+
+my $cpanfile = Path::Tiny->tempfile;
+$cpanfile->spew(<<'___');
+requires 'Distribution::Metadata', '== 0.04';
+___
+
+my $snapshot = Path::Tiny->tempfile;
+$snapshot->spew(<<'___');
+# carton snapshot format: version 1.0
+DISTRIBUTIONS
+  CPAN-DistnameInfo-0.12
+    pathname: G/GB/GBARR/CPAN-DistnameInfo-0.12.tar.gz
+    provides:
+      CPAN::DistnameInfo 0.12
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
+  Distribution-Metadata-0.04
+    pathname: S/SK/SKAJI/Distribution-Metadata-0.04.tar.gz
+    provides:
+      Distribution::Metadata 0.04
+      Distribution::Metadata::Factory undef
+    requirements:
+      CPAN::DistnameInfo 0
+      CPAN::Meta 0
+      ExtUtils::MakeMaker 0
+      ExtUtils::Packlist 0
+      JSON 0
+      Module::Metadata 0
+      perl 5.008001
+  JSON-2.90
+    pathname: M/MA/MAKAMAKA/JSON-2.90.tar.gz
+    provides:
+      JSON 2.90
+      JSON::Backend::PP 2.90
+      JSON::Boolean 2.90
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0
+___
+
+
+my $r;
+with_same_local {
+    $r = cpm_install "--cpanfile", $cpanfile->stringify, "--snapshot", $snapshot->stringify;
+    like $r->err, qr/DONE install Distribution-Metadata-0.04/;
+    note explain $r;
+
+    $r = cpm_install "--cpanfile", $cpanfile->stringify, "--snapshot", $snapshot->stringify;
+    like $r->err, qr/All requirements are satisfied\./;
+    note explain $r;
+};
+
+done_testing;


### PR DESCRIPTION
Let's introduce App::cpm::Worker::Resolver::* classes.

There are several ways to resolve "where the module is":
* http://cpanmetadb.plackperl.org/
* http://some-cpan-mirror/modules/02packages.details.txt.gz
* /local/path/to/02packages.details.txt.gz
* metacapn api
* cpanfile
* cpanfile.snapshot
* custom api (such as https://stratopan.com/)

And people sometimes want to multiplex these sources in some ways.

This PR is a beginning of supporting these.