### PR TITLE
Add carton cpanm options

### DIFF
--- a/lib/App/cpm.pm
+++ b/lib/App/cpm.pm
@@ -44,6 +44,7 @@ sub parse_options {
         "h|help" => sub { $self->cmd_help },
         "mirror=s@" => \@mirror,
         "v|verbose" => \($self->{verbose}),
+        "q|quiet!"  => \($self->{quiet}),
         "w|workers=i" => \($self->{workers}),
         "target-perl=s" => \my $target_perl,
         "test!" => sub { $self->{notest} = $_[1] ? 0 : 1 },

--- a/lib/App/cpm.pm
+++ b/lib/App/cpm.pm
@@ -51,6 +51,7 @@ sub parse_options {
         "cpanfile=s" => \($self->{cpanfile}),
         "snapshot=s" => \($self->{snapshot}),
         "sudo" => \($self->{sudo}),
+        "save-dists=s" => \($self->{save_dists}),
     or exit 1;
 
     $self->{local_lib} = abs_path $self->{local_lib} unless $self->{global};
@@ -153,7 +154,7 @@ sub cmd_install {
         verbose         => $self->{verbose},
         mirror          => $self->{mirror},
         menlo_base      => "$ENV{HOME}/.perl-cpm/work",
-        menlo_cache     => "$ENV{HOME}/.perl-cpm/cache",
+        menlo_cache     => $self->{save_dists} || "$ENV{HOME}/.perl-cpm/cache",
         menlo_build_log => "$ENV{HOME}/.perl-cpm/build.@{[time]}.log",
         notest          => $self->{notest},
         sudo            => $self->{sudo},

--- a/lib/App/cpm.pm
+++ b/lib/App/cpm.pm
@@ -52,6 +52,7 @@ sub parse_options {
         "snapshot=s" => \($self->{snapshot}),
         "sudo" => \($self->{sudo}),
         "save-dists=s" => \($self->{save_dists}),
+        "with-develop" => \($self->{with_develop}),
     or exit 1;
 
     $self->{local_lib} = abs_path $self->{local_lib} unless $self->{global};
@@ -215,10 +216,18 @@ sub setup {
     for my $arg (@argv) {
         if (-d $arg or $arg =~ /(?:^git:|\.git(?:@.+)?$)/) {
             $arg = abs_path $arg if -d $arg;
-            my $dist = App::cpm::Distribution->new(distfile => $arg, provides => []);
+            my $dist = App::cpm::Distribution->new(
+                distfile => $arg,
+                provides => [],
+                with_develop => $self->{with_develop},
+            );
             $master->add_distribution($dist);
         } else {
-            push @package, {package => $arg, version => 0};
+            push @package, {
+                package => $arg,
+                version => 0,
+                with_develop => $self->{with_develop},
+            };
         }
     }
 
@@ -248,7 +257,8 @@ sub setup {
         $master->add_job(
             type => "resolve",
             package => $p->{package},
-            version => $p->{version} || 0
+            version => $p->{version} || 0,
+            with_develop => $p->{with_develop},
         );
     }
 }

--- a/lib/App/cpm.pm
+++ b/lib/App/cpm.pm
@@ -53,6 +53,7 @@ sub parse_options {
         "sudo" => \($self->{sudo}),
         "save-dists=s" => \($self->{save_dists}),
         "with-develop" => \($self->{with_develop}),
+        "with-all-features" => sub { $self->{features}{__all} = 1 },
     or exit 1;
 
     $self->{local_lib} = abs_path $self->{local_lib} unless $self->{global};
@@ -219,6 +220,7 @@ sub setup {
             my $dist = App::cpm::Distribution->new(
                 distfile => $arg,
                 provides => [],
+                features => $self->{features},
                 with_develop => $self->{with_develop},
             );
             $master->add_distribution($dist);
@@ -226,6 +228,7 @@ sub setup {
             push @package, {
                 package => $arg,
                 version => 0,
+                features => $self->{features},
                 with_develop => $self->{with_develop},
             };
         }
@@ -258,6 +261,7 @@ sub setup {
             type => "resolve",
             package => $p->{package},
             version => $p->{version} || 0,
+            features => $self->{features},
             with_develop => $p->{with_develop},
         );
     }

--- a/lib/App/cpm/Distribution.pm
+++ b/lib/App/cpm/Distribution.pm
@@ -18,6 +18,7 @@ for my $attr (qw(
     meta
     provides
     requirements
+    with_develop
 )) {
     no strict 'refs';
     *$attr = sub {

--- a/lib/App/cpm/Distribution.pm
+++ b/lib/App/cpm/Distribution.pm
@@ -18,6 +18,7 @@ for my $attr (qw(
     meta
     provides
     requirements
+    features
     with_develop
 )) {
     no strict 'refs';

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -102,6 +102,7 @@ sub _calculate_jobs {
                     meta => $dist->meta,
                     directory => $dist->directory,
                     distfile => $dist->distfile,
+                    features => $dist->features,
                     with_develop => $dist->with_develop,
                 );
             } elsif (@need_resolve) {
@@ -262,6 +263,7 @@ sub _register_resolve_result {
     my $distribution = App::cpm::Distribution->new(
         distfile => $job->{distfile},
         provides => $job->{provides},
+        features => $job->{features},
         with_develop => $job->{with_develop},
     );
     $self->add_distribution($distribution, $job->{provides});

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -102,6 +102,7 @@ sub _calculate_jobs {
                     meta => $dist->meta,
                     directory => $dist->directory,
                     distfile => $dist->distfile,
+                    with_develop => $dist->with_develop,
                 );
             } elsif (@need_resolve) {
                 my $ok = $self->_register_resolve_job(@need_resolve);
@@ -261,6 +262,7 @@ sub _register_resolve_result {
     my $distribution = App::cpm::Distribution->new(
         distfile => $job->{distfile},
         provides => $job->{provides},
+        with_develop => $job->{with_develop},
     );
     $self->add_distribution($distribution, $job->{provides});
 }

--- a/lib/App/cpm/Worker/Installer.pm
+++ b/lib/App/cpm/Worker/Installer.pm
@@ -31,7 +31,12 @@ sub work {
         }
     } elsif ($type eq "configure") {
         my ($distdata, $requirements)
-            = $self->configure($job->{directory}, $job->{distfile}, $job->{meta});
+            = $self->configure(
+                $job->{directory},
+                $job->{distfile},
+                $job->{meta},
+                $job->{with_develop},
+            );
         if ($requirements) {
             return +{
                 ok => 1,
@@ -166,7 +171,7 @@ sub _extract_requirements {
 }
 
 sub configure {
-    my ($self, $dir, $distfile, $meta) = @_;
+    my ($self, $dir, $distfile, $meta, $with_develop) = @_;
     my $guard = pushd $dir;
     my $menlo = $self->menlo;
     if (-f 'Build.PL') {
@@ -179,6 +184,8 @@ sub configure {
     my $distdata = $self->_build_distdata($distfile, $meta);
     my $requirements = [];
     my $phase = $self->{notest} ? [qw(build runtime)] : [qw(build test runtime)];
+    push @$phase, 'develop' if $with_develop;
+
     if (my ($file) = grep -f, qw(MYMETA.json MYMETA.yml)) {
         my $mymeta = CPAN::Meta->load_file($file);
         $requirements = $self->_extract_requirements($mymeta, $phase);

--- a/xt/17_with_develop.t
+++ b/xt/17_with_develop.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use xt::CLI;
+use xt::Dist;
+use Path::Tiny;
+
+my $dist = dist(
+    name    => 'develop-requires',
+    prereqs => {
+        runtime => {
+            requires => {'Module::Build' => 0},
+        },
+        develop => {
+            requires => {'HTTP::Tinyish' => 0},
+        },
+    },
+);
+
+subtest default => sub {
+    my $r = cpm_install $dist;
+    unlike $r->err, qr/^DONE install HTTP-Tinyish/m or diag $r->err;
+};
+
+subtest with_develop => sub {
+    my $r = cpm_install $dist, '--with-develop';
+    like $r->err, qr/^DONE install HTTP-Tinyish/m or diag $r->err;
+};
+
+done_testing;

--- a/xt/18_with_all_features.t
+++ b/xt/18_with_all_features.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use xt::CLI;
+use xt::Dist;
+use Path::Tiny;
+
+my $dist = dist(
+    name => 'has-features',
+    prereqs => {
+        runtime => {requires => {'Module::Build' => 0}},
+    },
+    optional_features => {
+        'my-feature' => {
+            prereqs => {
+                runtime => {requires => {'HTTP::Tinyish' => 0}},
+            },
+        },
+    },
+);
+
+subtest default => sub {
+    my $r = cpm_install $dist;
+    unlike $r->err, qr/^DONE install HTTP-Tinyish/m or diag $r->err;
+};
+
+subtest with_all_features => sub {
+    my $r = cpm_install $dist, '--with-all-features';
+    like $r->err, qr/^DONE install HTTP-Tinyish/m or diag $r->err;
+};
+
+done_testing;

--- a/xt/Dist.pm
+++ b/xt/Dist.pm
@@ -1,0 +1,56 @@
+package xt::Dist;
+use strict;
+use warnings;
+use utf8;
+
+use CPAN::Meta;
+use Path::Tiny;
+use Exporter 'import';
+our @EXPORT = qw(dist);
+
+sub dist {
+    my (%args) = @_;
+    my $name    = $args{name};
+    my $version = $args{version} || '0.0.1';
+
+    (my $package = $name) =~ s/\W/_/g;
+    my $provides = {
+        $package => {
+            file    => "$package.pm",
+            version => $version,
+        },
+    };
+
+    my $meta = CPAN::Meta->new({
+        abstract => "dummy dist for $name",
+        author   => ['unknown'],
+        license  => ['unknown'],
+        version  => $version,
+        dynamic_config => 1,
+        generated_by   => ['xt::CLI'],
+        'meta-spec'    => {
+          version => '2',
+          url     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
+        },
+        release_status => 'stable',
+        provides => $provides,
+        %args,
+    });
+
+    my $dir = Path::Tiny->tempdir(CLEANUP => 1);
+    $dir->child('META.json')->spew($meta->as_string);
+    $dir->child('MANIFEST')->spew(join "\n", qw(Makefile.PL MANIFEST META.json), "$package.pm");
+    $dir->child("$package.pm")->spew("package $package; our \$VERSION = $version; 1");
+
+    $dir->child('Makefile.PL')->spew(<<"__END__");
+use ExtUtils::MakeMaker;
+WriteMakefile(
+    NAME    => '$name',
+    VERSION => '$version',
+);
+__END__
+
+    return $dir;
+}
+
+1;


### PR DESCRIPTION
I'd love to try and help get cpm usable by carton, so I took a stab at implementing a number of cpanm options carton typically uses. I believe the only often used option that is still missing is the `--cascade-search` option. The other major feature we'd still have to implement for carton would be the history API lookups, for finding perl module versions that are no longer considered latest.

There were also a few things that could possibly be cleaned up more, that I'd love to get your opinion on.
1. The quiet option doesn't do anything. I supposed we could use this to make the logging output even less verbose. The commit here does nothing, as the cpanm quiet output is of the same verbosity as normal cpm output. Maybe we should just remove this, and make sure carton doesn't pass it?
2. Some of the argument lists are getting rather long(especially in the installer class), and may make sense to either rewrite as hash arguments, or perhaps we should just pass around an object that already has a lot of these values(such as the distribution object).
3. The with-develop and with-all-features implementations might be using the distribution objects for too much. I wasn't sure how we should handle the state required for implementing these features - the cpanm / menlo implementations rely on a `$depth` parameter that cpm does not track. Maybe I should figure out how to move this state somewhere else in the master?
   
   Or perhaps using futures/promises to linearize the flow of an install may make the state easier to manage. I'm very fuzzy on the details of how that may help(I'd probably have to take a first stab at writing this to see if it would be worthwhile), and this would also require a fairly substantial rewrite of the master. I figured I'd just float the idea as a possible way to handle concurrency without all the `_register_*_result` callbacks, which tend to complicate managing the state used by these options.
