### PR TITLE
use App::cpm::Logger::File

### DIFF
--- a/lib/App/cpm/Distribution.pm
+++ b/lib/App/cpm/Distribution.pm
@@ -6,11 +6,12 @@ use App::cpm::Logger;
 use CPAN::DistnameInfo;
 our $VERSION = '0.214';
 
-use constant STATE_REGISTERED => 0b00001;
-use constant STATE_RESOLVED   => 0b00010; # default
-use constant STATE_FETCHED    => 0b00100;
-use constant STATE_CONFIGURED => 0b01000;
-use constant STATE_INSTALLED  => 0b10000;
+use constant STATE_REGISTERED      => 0b000001;
+use constant STATE_DEPS_REGISTERED => 0b000010;
+use constant STATE_RESOLVED        => 0b000100; # default
+use constant STATE_FETCHED         => 0b001000;
+use constant STATE_CONFIGURED      => 0b010000;
+use constant STATE_INSTALLED       => 0b100000;
 
 sub new {
     my ($class, %option) = @_;
@@ -74,6 +75,14 @@ sub registered {
         $self->{_state} |= STATE_REGISTERED;
     }
     $self->{_state} & STATE_REGISTERED;
+}
+
+sub deps_registered {
+    my $self = shift;
+    if (@_ && $_[0]) {
+        $self->{_state} |= STATE_DEPS_REGISTERED;
+    }
+    $self->{_state} & STATE_DEPS_REGISTERED;
 }
 
 sub resolved {

--- a/lib/App/cpm/Logger/File.pm
+++ b/lib/App/cpm/Logger/File.pm
@@ -1,0 +1,52 @@
+package App::cpm::Logger::File;
+use strict;
+use warnings;
+use POSIX ();
+our $VERSION = '0.214';
+
+sub new {
+    my ($class, $file) = @_;
+    open my $fh, ">>:unix", $file or die "$file: $!";
+    bless {
+        context => '',
+        fh => $fh,
+        file => $file,
+    }, $class;
+}
+
+sub symlink_to {
+    return unless eval { symlink "", ""; 1 };
+    my ($self, $dest) = @_;
+    unlink $dest;
+    symlink $self->file, $dest;
+}
+
+sub file {
+    shift->{file};
+}
+
+sub context {
+    my $self = shift;
+    $self->{context} ? ",$self->{context}" : "";
+}
+
+sub log {
+    my $self = shift;
+    my $now = POSIX::strftime('%FT%T', localtime);
+    my $context = $self->context;
+    for my $line (@_) {
+        chomp $line;
+        print { $self->{fh} } "$now,${$}$context| $_\n" for split /\n/, $line;
+    }
+}
+
+sub log_with_fh {
+    my ($self, $fh) = @_;
+    my $context = $self->context;
+    while (my $line = <$fh>) {
+        chomp $line;
+        print { $self->{fh} } "@{[POSIX::strftime('%FT%T', localtime)]},${$}$context| $line\n";
+    }
+}
+
+1;

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -118,7 +118,12 @@ sub _calculate_jobs {
                     source => $dist->source,
                     uri => $dist->uri,
                 );
-            } elsif (@need_resolve) {
+            } elsif (@need_resolve and !$dist->deps_registered) {
+                $dist->deps_registered(1);
+                local $self->{logger}->{context} = $dist->distvname;
+                my $msg = sprintf "Found configure dependencies: %s",
+                    join(", ", map { sprintf "%s (%s)", $_->{package}, $_->{version} || 0 }  @need_resolve);
+                $self->{logger}->log($msg);
                 my $ok = $self->_register_resolve_job(@need_resolve);
                 $self->{_fail_install}{$dist->distfile}++ unless $ok;
             } elsif (!defined $is_satisfied) {
@@ -144,7 +149,12 @@ sub _calculate_jobs {
                     distfile => $dist->{distfile},
                     uri => $dist->uri,
                 );
-            } elsif (@need_resolve) {
+            } elsif (@need_resolve and !$dist->deps_registered) {
+                $dist->deps_registered(1);
+                local $self->{logger}->{context} = $dist->distvname;
+                my $msg = sprintf "Found dependencies: %s",
+                    join(", ", map { sprintf "%s (%s)", $_->{package}, $_->{version} || 0 }  @need_resolve);
+                $self->{logger}->log($msg);
                 my $ok = $self->_register_resolve_job(@need_resolve);
                 $self->{_fail_install}{$dist->distfile}++ unless $ok;
             } elsif (!defined $is_satisfied) {

--- a/lib/App/cpm/Worker.pm
+++ b/lib/App/cpm/Worker.pm
@@ -12,8 +12,16 @@ use Time::HiRes qw(gettimeofday tv_interval);
 
 sub new {
     my ($class, %option) = @_;
+    my $home = $option{home};
+    my $logger = $option{logger} || App::cpm::Logger::File->new("$home/build.log.@{[time]}");
+    %option = (
+        %option,
+        logger => $logger,
+        base => "$home/work",
+        cache => "$home/cache",
+    );
     my $installer = App::cpm::Worker::Installer->new(%option);
-    my $resolver  = App::cpm::Worker::Resolver->new(impl => $option{resolver});
+    my $resolver  = App::cpm::Worker::Resolver->new(%option, impl => $option{resolver});
     bless { %option, installer => $installer, resolver => $resolver }, $class;
 }
 

--- a/lib/App/cpm/Worker/Installer/Menlo.pm
+++ b/lib/App/cpm/Worker/Installer/Menlo.pm
@@ -1,0 +1,123 @@
+package App::cpm::Worker::Installer::Menlo;
+use strict;
+use warnings;
+use parent 'Menlo::CLI::Compat';
+
+use App::cpm::Logger::File;
+use File::Temp ();
+use POSIX ();
+
+our $VERSION = '0.214';
+
+use constant WIN32 => Menlo::CLI::Compat::WIN32();
+
+sub new {
+    my ($class, %option) = @_;
+    $option{log} ||= $option{logger}->file;
+    my $self = $class->SUPER::new(%option);
+    $self->init_tools;
+    $self->_set_http_agent;
+    $self;
+}
+
+sub _set_http_agent {
+    my $self = shift;
+    my $agent = "App::cpm/$VERSION";
+    my $http = $self->{http};
+    my $klass = ref $http;
+    if ($klass =~ /HTTP::Tinyish::(Curl|Wget)/) {
+        $http->{agent} = $agent;
+    } elsif ($klass eq 'HTTP::Tinyish::LWP') {
+        $http->{ua}->agent($agent);
+    } elsif ($klass eq 'HTTP::Tinyish::HTTPTiny') {
+        $http->{tiny}->agent($agent);
+    } else {
+        die "Unknown http class: $klass\n";
+    }
+}
+
+sub log {
+    my $self = shift;
+    $self->{logger}->log(@_);
+}
+
+sub run_command {
+    my($self, $cmd) = @_;
+
+    # TODO move to a more appropriate runner method
+    if (ref $cmd eq 'CODE') {
+        if ($self->{verbose}) {
+            return $cmd->();
+        } else {
+            require Capture::Tiny;
+            open my $fh, "+>", undef;
+            my $ret;
+            Capture::Tiny::capture(sub { $ret = $cmd->() }, stdout => $fh, stderr => $fh);
+            seek $fh, 0, 0;
+            $self->{logger}->log_with_fh($fh);
+            return $ret;
+        }
+    }
+
+    if (WIN32) {
+        # TODO
+        $cmd = Menlo::Util::shell_quote(@$cmd) if ref $cmd eq 'ARRAY';
+        unless ($self->{verbose}) {
+            $cmd .= " >> " . Menlo::Util::shell_quote($self->{log}) . " 2>&1";
+        }
+        !system $cmd;
+    } else {
+        $self->run_exec($cmd);
+    }
+}
+
+sub run_exec {
+    my($self, $cmd) = @_;
+
+    my $pid = open my $fh, "-|";
+    if ($pid == 0) {
+        open STDERR, ">&", \*STDOUT;
+        if (ref $cmd eq 'ARRAY') {
+            exec {$cmd->[0]} @$cmd;
+        } else {
+            exec $cmd;
+        }
+        exit 255;
+    } else {
+        $self->{logger}->log_with_fh($fh);
+        close $fh;
+        return !$?;
+    }
+}
+
+sub run_timeout {
+    my($self, $cmd, $timeout) = @_;
+
+    return $self->run_command($cmd) if ref($cmd) eq 'CODE' || WIN32 || $self->{verbose} || !$timeout;
+
+    my $pid = fork;
+    if ($pid) {
+        eval {
+            local $SIG{ALRM} = sub { die "alarm\n" };
+            alarm $timeout;
+            waitpid $pid, 0;
+            alarm 0;
+        };
+        if ($@ && $@ eq "alarm\n") {
+            $self->diag_fail("Timed out (> ${timeout}s). Use --verbose to retry.");
+            local $SIG{TERM} = 'IGNORE';
+            kill TERM => 0;
+            waitpid $pid, 0;
+            return;
+        }
+        return !$?;
+    } elsif ($pid == 0) {
+        my $ret = $self->run_exec($cmd);
+        exit($ret ? 0 : 1);
+    } else {
+        $self->chat("! fork failed: falling back to system()\n");
+        $self->run_command($cmd);
+    }
+}
+
+1;

--- a/lib/App/cpm/Worker/Resolver.pm
+++ b/lib/App/cpm/Worker/Resolver.pm
@@ -2,19 +2,33 @@ package App::cpm::Worker::Resolver;
 use strict;
 use warnings;
 our $VERSION = '0.214';
+use File::Temp ();
+use App::cpm::Logger::File;
 
 sub new {
     my ($class, %option) = @_;
-    bless { impl => $option{impl} }, $class;
+    my $logger = $option{logger};
+    if (!$logger) {
+        (undef, my $file) = File::Temp::tempfile(UNLINK => 1);
+        $logger = App::cpm::Logger::File->new($file);
+    }
+    bless { impl => $option{impl}, logger => $logger }, $class;
 }
 
 sub work {
     my ($self, $job) = @_;
+
+    local $self->{logger}->{context} = $job->{package};
     if (my $result = $self->{impl}->resolve($job)) {
         $result->{ok} = 1;
         $result->{uri} = [$result->{uri}] unless ref $result->{uri};
+        my $msg = sprintf "Resolved %s (%s) -> %s", $job->{package}, $job->{version} || 0,
+            $result->{uri}[0] . ($result->{from} ? " from $result->{from}" : "");
+        $self->{logger}->log($msg);
         return $result;
     } else {
+        my $msg = sprintf "Failed to resolve %s", $job->{package};
+        $self->{logger}->log($msg);
         return { ok => 0 };
     }
 }

--- a/xt/02_installer.t
+++ b/xt/02_installer.t
@@ -3,6 +3,7 @@ use warnings;
 use utf8;
 use Test::More;
 use App::cpm::Worker::Installer;
+use App::cpm::Job;
 use File::Temp 'tempdir';
 
 my $tempdir = tempdir CLEANUP => 1;
@@ -17,34 +18,24 @@ my ($job, $result);
 
 my $mirror = "http://www.cpan.org";
 my $distfile = "S/SK/SKAJI/Distribution-Metadata-0.05.tar.gz";
-$job = {
+
+my %default = (
     source => "cpan",
-    distfile => "S/SK/SKAJI/Distribution-Metadata-0.05.tar.gz",
+    distfile => $distfile,
     uri => ["$mirror/authors/id/$distfile"],
     type => "fetch",
-};
+);
+
+$job = App::cpm::Job->new(%default);
 $result = $installer->work($job);
 ok exists $result->{$_} for qw(ok meta configure_requirements directory);
 
-$job = {
-    %$job,
-    %$result,
-    type => "configure",
-};
+$job = App::cpm::Job->new(%default, %$result, type => "configure");
 $result = $installer->work($job);
 ok exists $result->{$_} for qw(ok requirements distdata);
 
-$job = {
-    %$job,
-    %$result,
-    type => "install",
-};
-
+$job = App::cpm::Job->new(%default, %$result, type => "install");
 $result = $installer->work($job);
-$job = {
-    %$job,
-    %$result,
-};
 ok exists $result->{$_} for qw(ok);
 
 done_testing;


### PR DESCRIPTION
fix #51 

As mentioned in README, cpm's log is really messy, so it is difficult to find out the reason of failure from the log file.

Now cpm uses App::cpm::Logger::File to emit log, which hopefully helps you.
```
> cpm install Plack
...
> less ~/.perl-cpm/build.log
2016-12-10T11:08:16,86583| You have make /usr/bin/make
2016-12-10T11:08:16,86583| You have LWP: 6.15
2016-12-10T11:08:16,86583| You have LWP::Protocol::https: 6.06
2016-12-10T11:08:16,86583| You have /usr/local/opt/gnu-tar/libexec/gnubin/tar: tar (GNU tar) 1.29
2016-12-10T11:08:16,86583| Copyright (C) 2015 Free Software Foundation, Inc.
2016-12-10T11:08:16,86583| License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
2016-12-10T11:08:16,86583| This is free software: you are free to change and redistribute it.
2016-12-10T11:08:16,86583| There is NO WARRANTY, to the extent permitted by law.
2016-12-10T11:08:16,86583|
2016-12-10T11:08:16,86583| Written by John Gilmore and Jay Fenlason.
2016-12-10T11:08:16,86583| You have /usr/bin/unzip
2016-12-10T11:08:16,86601,Plack| Resolved Plack (0) -> file:///Users/skaji/cache/authors/id/M/MI/MIYAGAWA/Plack-1.0042.tar.gz from 02Packages
2016-12-10T11:08:16,86601,Plack-1.0042| Unpacking Plack-1.0042.tar.gz
2016-12-10T11:08:16,86583,Plack-1.0042| Found configure dependencies: File::ShareDir::Install (0.06)
2016-12-10T11:08:16,86601,File::ShareDir::Install| Resolved File::ShareDir::Install (0.06) -> file:///Users/skaji/cache/authors/id/E/ET/ETHER/File-ShareDir-Install-0.11.tar.gz from 02Packages
2016-12-10T11:08:16,86601,File-ShareDir-Install-0.11| Unpacking File-ShareDir-Install-0.11.tar.gz
2016-12-10T11:08:16,86583,File-ShareDir-Install-0.11| Found configure dependencies: Module::Build::Tiny (0.034)
2016-12-10T11:08:16,86601,Module::Build::Tiny| Resolved Module::Build::Tiny (0.034) -> file:///Users/skaji/cache/authors/id/L/LE/LEONT/Module-Build-Tiny-0.039.tar.gz from 02Packages
2016-12-10T11:08:16,86601,Module-Build-Tiny-0.039| Unpacking Module-Build-Tiny-0.039.tar.gz
...
```
where the prefix is `time`, `pid`, `package|distribution`.