### PR TITLE
fix up-to-date handling

### DIFF
--- a/lib/App/cpm.pm
+++ b/lib/App/cpm.pm
@@ -273,18 +273,18 @@ sub register_initial_job {
             my $dist = App::cpm::Distribution->new(source => "http", uri => $arg, provides => []);
             $master->add_distribution($dist);
         } else {
-            my ($package, $version, $dev);
+            my ($package, $version_range, $dev);
             # copy from Menlo
             # Plack@1.2 -> Plack~"==1.2"
             $arg =~ s/^([A-Za-z0-9_:]+)@([v\d\._]+)$/$1~== $2/;
             # support Plack~1.20, DBI~"> 1.0, <= 2.0"
             if ($arg =~ /\~[v\d\._,\!<>= ]+$/) {
-                ($package, $version) = split '~', $arg, 2;
+                ($package, $version_range) = split '~', $arg, 2;
             } else {
                 $arg =~ s/[~@]dev$// and $dev++;
                 $package = $arg;
             }
-            push @package, {package => $package, version => $version || 0, dev => $dev};
+            push @package, {package => $package, version_range => $version_range || 0, dev => $dev};
         }
     }
 
@@ -297,7 +297,7 @@ sub register_initial_job {
             exit 0;
         } elsif (!defined $is_satisfied) {
             my ($req) = grep { $_->{package} eq "perl" } @$requirements;
-            die sprintf "%s requires perl %s\n", $self->{cpanfile}, $req->{version};
+            die sprintf "%s requires perl %s\n", $self->{cpanfile}, $req->{version_range};
         } else {
             @package = @need_resolve;
         }
@@ -307,7 +307,7 @@ sub register_initial_job {
         $master->add_job(
             type => "resolve",
             package => $p->{package},
-            version => $p->{version} || 0,
+            version_range => $p->{version_range} || 0,
             dev => $p->{dev},
         );
     }
@@ -339,7 +339,7 @@ sub load_cpanfile {
             );
         } else {
             push @package, {
-                package => $package, version => $hash->{$package}, dev => $option->{dev},
+                package => $package, version_range => $hash->{$package}, dev => $option->{dev},
             };
         }
     }

--- a/lib/App/cpm/Distribution.pm
+++ b/lib/App/cpm/Distribution.pm
@@ -118,14 +118,14 @@ sub installed {
 }
 
 sub providing {
-    my ($self, $package, $version) = @_;
+    my ($self, $package, $version_range) = @_;
     for my $provide (@{$self->provides}) {
         if ($provide->{package} eq $package) {
-            if (!$version or App::cpm::version->parse($provide->{version})->satisfy($version)) {
+            if (!$version_range or App::cpm::version->parse($provide->{version})->satisfy($version_range)) {
                 return 1;
             } else {
                 my $message = sprintf "%s provides %s (%s), but needs %s\n",
-                    $self->distfile, $package, $provide->{version}, $version;
+                    $self->distfile, $package, $provide->{version} || 0, $version_range;
                 App::cpm::Logger->log(result => "WARN", message => $message);
                 last;
             }

--- a/lib/App/cpm/Resolver/02Packages.pm
+++ b/lib/App/cpm/Resolver/02Packages.pm
@@ -90,9 +90,9 @@ sub resolve {
     my $result = $self->{impl}->search_packages({package => $job->{package}});
     return unless $result;
 
-    if (my $req_version = $job->{version}) {
+    if (my $version_range = $job->{version_range}) {
         my $version = $result->{version};
-        if (!App::cpm::version->parse($version)->satisfy($req_version)) {
+        if (!App::cpm::version->parse($version)->satisfy($version_range)) {
             return;
         }
     }

--- a/lib/App/cpm/Resolver/Cascade.pm
+++ b/lib/App/cpm/Resolver/Cascade.pm
@@ -16,7 +16,7 @@ sub add {
 
 sub resolve {
     my ($self, $job) = @_;
-    # here job = { package => "Plack", version => ">= 1.000, < 1.0030" }
+    # here job = { package => "Plack", version_range => ">= 1.000, < 1.0030" }
 
     for my $backend (@{ $self->{backends} }) {
         my $result = $backend->resolve($job);

--- a/lib/App/cpm/Resolver/MetaCPAN.pm
+++ b/lib/App/cpm/Resolver/MetaCPAN.pm
@@ -36,7 +36,7 @@ sub resolve {
 
     my %query = (
         ( ($self->{dev} || $job->{dev}) ? (dev => 1) : () ),
-        ( $job->{version} ? (version => $job->{version}) : () ),
+        ( $job->{version_range} ? (version => $job->{version_range}) : () ),
     );
     my $query = join "&", map { "$_=" . _encode($query{$_}) } sort keys %query;
     my $uri = "$self->{uri}$job->{package}" . ($query ? "?$query" : "");

--- a/lib/App/cpm/Resolver/MetaDB.pm
+++ b/lib/App/cpm/Resolver/MetaDB.pm
@@ -26,7 +26,7 @@ sub new {
 sub resolve {
     my ($self, $job) = @_;
 
-    if (defined $job->{version} and $job->{version} =~ /(?:<|!=|==)/) {
+    if (defined $job->{version_range} and $job->{version_range} =~ /(?:<|!=|==)/) {
         my $res = $self->{http}->get( "$self->{uri}history/$job->{package}" );
         return unless $res->{success};
 
@@ -46,7 +46,7 @@ sub resolve {
 
         my $match;
         for my $try (sort { $b->{version_o} <=> $a->{version_o} } @found) {
-            if ($try->{version_o}->satisfy($job->{version})) {
+            if ($try->{version_o}->satisfy($job->{version_range})) {
                 $match = $try, last;
             }
         }
@@ -67,7 +67,7 @@ sub resolve {
 
         my $yaml = CPAN::Meta::YAML->read_string($res->{content});
         my $meta = $yaml->[0];
-        if (!App::cpm::version->parse($meta->{version})->satisfy($job->{version})) {
+        if (!App::cpm::version->parse($meta->{version})->satisfy($job->{version_range})) {
             return;
         }
         my @provides = map {

--- a/lib/App/cpm/Resolver/Snapshot.pm
+++ b/lib/App/cpm/Resolver/Snapshot.pm
@@ -28,8 +28,8 @@ sub resolve {
     return unless $found;
 
     my $version = $found->version_for($package);
-    if (my $req_version = $job->{version}) {
-        if (!App::cpm::version->parse($version)->satisfy($req_version)) {
+    if (my $version_range = $job->{version_range}) {
+        if (!App::cpm::version->parse($version)->satisfy($version_range)) {
             return;
         }
     }

--- a/lib/App/cpm/Worker/Installer.pm
+++ b/lib/App/cpm/Worker/Installer.pm
@@ -219,7 +219,7 @@ sub _get_configure_requirements {
 
     if (!@$requirements && -f "Build.PL" && $distfile !~ m{/Module-Build-[0-9v]}) {
         push @$requirements, {
-            package => "Module::Build", version => "0.38",
+            package => "Module::Build", version_range => "0.38",
             phase => "configure", type => "requires",
         };
     }
@@ -236,7 +236,7 @@ sub _extract_requirements {
         my $reqs = ($hash->{$phase} || +{})->{requires} || +{};
         for my $package (sort keys %$reqs) {
             push @requirements, {
-                package => $package, version => $reqs->{$package},
+                package => $package, version_range => $reqs->{$package},
                 phase => $phase, type => "requires",
             };
         }

--- a/lib/App/cpm/version.pm
+++ b/lib/App/cpm/version.pm
@@ -7,13 +7,13 @@ our $VERSION = '0.292';
 use parent 'version';
 
 sub satisfy {
-    my ($self, $want_ver) = @_;
+    my ($self, $version_range) = @_;
 
-    return 1 unless $want_ver;
-    return $self >= version->parse($want_ver) if $want_ver =~ /^v?[\d_.]+$/;
+    return 1 unless $version_range;
+    return $self >= version->parse($version_range) if $version_range =~ /^v?[\d_.]+$/;
 
     my $requirements = CPAN::Meta::Requirements->new;
-    $requirements->add_string_requirement('DummyModule', $want_ver);
+    $requirements->add_string_requirement('DummyModule', $version_range);
     $requirements->accepts_module('DummyModule', $self->numify);
 }
 

--- a/xt/01_installer.t
+++ b/xt/01_installer.t
@@ -27,7 +27,7 @@ is_deeply $configure_requirements, [
     package => "ExtUtils::MakeMaker",
     phase   => "configure",
     type    => "requires",
-    version => 0,
+    version_range => 0,
   },
 ];
 
@@ -44,7 +44,7 @@ is_deeply $requirements->[-1], {
     package => "perl",
     phase   => "runtime",
     type    => "requires",
-    version => "5.008001",
+    version_range => "5.008001",
 };
 
 done_testing;

--- a/xt/23_up_to_date.t
+++ b/xt/23_up_to_date.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use xt::CLI;
+
+# XXX assume the latest version of App-ChangeShebang is 0.06
+
+with_same_local {
+    my $r = cpm_install 'App::ChangeShebang@0.06';
+    is $r->exit, 0;
+    like $r->err, qr/DONE install App-ChangeShebang-0.06/;
+
+    $r = cpm_install 'App::ChangeShebang';
+    is $r->exit, 0;
+    like $r->err, qr/DONE install App::ChangeShebang is up to date/;
+
+    $r = cpm_install 'App::ChangeShebang@0.05';
+    is $r->exit, 0;
+    like $r->err, qr/DONE install App-ChangeShebang-0.05/;
+
+    $r = cpm_install 'App::ChangeShebang';
+    is $r->exit, 0;
+    like $r->err, qr/DONE install App-ChangeShebang-0.06/;
+};
+
+done_testing;


### PR DESCRIPTION
before
```
> perl -Ilib script/cpm install App::ChangeShebang@0.06
DONE install App-ChangeShebang-0.06
1 distribution installed.

> perl -Ilib script/cpm install App::ChangeShebang@0.05
DONE install App::ChangeShebang is up to date. (0.05)
0 distribution installed.
```

Now
```
> perl -Ilib script/cpm install App::ChangeShebang@0.06
DONE install App-ChangeShebang-0.06
1 distribution installed.

> perl -Ilib script/cpm install App::ChangeShebang@0.05
DONE install App-ChangeShebang-0.05
1 distribution installed.
```

Note that this PR also contains a change for App::cpm::Resolver interface.
Now App::cpm::Resolver->resolve will be called with
```
$job = {
    package => "Plack",
    version_range => "< 2.000, >= 1.000", # previously "version" key name
}
``` 
