### PR TITLE
do not assume core modules are always present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ perl:
   - '5.12'
   - '5.10'
   - '5.8'
+addons:
+  apt:
+    packages:
+    - libdb-dev
 install:
   - cpanm -nq --installdeps --with-develop .
   - cpanm -nq Carton

--- a/xt/24_core.t
+++ b/xt/24_core.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+use Test::More;
+use xt::CLI;
+use Path::Tiny;
+use Module::Metadata;
+use Config;
+use File::Spec;
+
+sub has_DB_File {
+    my @inc = @_;
+    my @core = (
+        (grep {$_} @Config{qw(vendorarch vendorlibexp)}),
+        @Config{qw(archlibexp privlibexp)},
+    );
+    my $info = Module::Metadata->new_from_module('DB_File', inc => [@core, @inc]);
+    $info ? 1 : 0;
+}
+
+if (has_DB_File()) {
+    note "Already has DB_File";
+} else {
+    note "Does not have DB_File";
+}
+
+my $cpanfile = Path::Tiny->tempfile;
+$cpanfile->spew("requires 'DB_File';\n");
+
+my $r = cpm_install "--cpanfile", "$cpanfile";
+note $r->err;
+is $r->exit, 0 or diag $r->err;
+
+my @lib = (
+    File::Spec->catdir($r->local, "lib/perl5"),
+    File::Spec->catdir($r->local, "lib/perl5/$Config{archname}"),
+);
+
+ok has_DB_File(@lib);
+
+done_testing;


### PR DESCRIPTION
fix #42 

cpm was checking whether a module is installed or not by:
```perl
sub installed {
   my ($self, $package, $version) = @_;
   return 1 if $package is core;
   return 1 if $package is in INC;
   return 0;
}
```

But some modules, which must be core, are not present. (Then what "core" means:/)

Now cpm do not assume core modules are always present,
so that it always checks modules are in INC or not.