### PR TITLE
keep prebuilts and use them later

### DIFF
--- a/lib/App/cpm/Distribution.pm
+++ b/lib/App/cpm/Distribution.pm
@@ -34,6 +34,7 @@ for my $attr (qw(
     requirements
     ref
     static_builder
+    prebuilt
 )) {
     no strict 'refs';
     *$attr = sub {

--- a/lib/App/cpm/Job.pm
+++ b/lib/App/cpm/Job.pm
@@ -44,6 +44,16 @@ sub distvname {
     }
 }
 
+sub distname {
+    my $self = shift;
+    $self->{_distname} ||= CPAN::DistnameInfo->new($self->distfile)->dist || 'UNKNOWN';
+}
+
+sub cpanid {
+    my $self = shift;
+    $self->{_cpanid} ||= CPAN::DistnameInfo->new($self->distfile)->cpanid || 'UNKNOWN';
+}
+
 sub type {
     my $self = shift;
     $self->{type};

--- a/lib/App/cpm/Logger.pm
+++ b/lib/App/cpm/Logger.pm
@@ -29,7 +29,7 @@ sub log {
     my $type = $option{type} || "";
     my $message = $option{message};
     chomp $message;
-    my $optional = $option{optional} ? "($option{optional})" : "";
+    my $optional = $option{optional} ? " ($option{optional})" : "";
     my $result = $option{result};
     my $is_color = ref $self ? $self->{color} : $COLOR;
     my $verbose = ref $self ? $self->{verbose} : $VERBOSE;
@@ -45,9 +45,9 @@ sub log {
     if ($verbose) {
         # type -> 5 + 9 + 3
         $type = $is_color && $type ? sprintf("%-17s", $type) : sprintf("%-9s", $type || "");
-        warn $r . sprintf "%d %s %s %s%s\n", $option{pid} || $$, $result, $type, $message, $optional ? " $optional" : "";
+        warn $r . sprintf "%d %s %s %s%s\n", $option{pid} || $$, $result, $type, $message, $optional;
     } else {
-        warn $r . join(" ", $result, $type ? $type : (), $message) . "\n";
+        warn $r . join(" ", $result, $type ? $type : (), $message . $optional) . "\n";
     }
 }
 

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -95,6 +95,7 @@ sub info {
     } else {
         $message = $name;
         $optional = "using cache" if $type eq "fetch" and $job->{using_cache};
+        $optional = "using prebuilt" if $job->{prebuilt};
     }
     my $elapsed = defined $job->{elapsed} ? sprintf "(%.3fsec) ", $job->{elapsed} : "";
 
@@ -195,6 +196,7 @@ sub _calculate_jobs {
                     distfile => $dist->{distfile},
                     uri => $dist->uri,
                     static_builder => $dist->static_builder,
+                    prebuilt => $dist->prebuilt,
                 );
             } elsif (@need_resolve and !$dist->deps_registered) {
                 $dist->deps_registered(1);
@@ -366,11 +368,18 @@ sub _register_fetch_result {
         return;
     }
     my $distribution = $self->distribution($job->distfile);
-    $distribution->fetched(1);
-    $distribution->configure_requirements($job->{configure_requirements});
     $distribution->directory($job->{directory});
     $distribution->meta($job->{meta});
     $distribution->provides($job->{provides});
+
+    if ($job->{prebuilt}) {
+        $distribution->configured(1);
+        $distribution->requirements($job->{requirements});
+        $distribution->prebuilt(1);
+    } else {
+        $distribution->fetched(1);
+        $distribution->configure_requirements($job->{configure_requirements});
+    }
     return 1;
 }
 

--- a/lib/App/cpm/Worker.pm
+++ b/lib/App/cpm/Worker.pm
@@ -6,6 +6,8 @@ our $VERSION = '0.352';
 
 use App::cpm::Worker::Installer;
 use App::cpm::Worker::Resolver;
+use Config;
+use Digest::MD5 ();
 use Time::HiRes qw(gettimeofday tv_interval);
 
 sub new {
@@ -17,10 +19,17 @@ sub new {
         logger => $logger,
         base => "$home/work/" . time . ".$$",
         cache => "$home/cache",
+        $option{prebuilt} ? (prebuilt_base => $class->prebuilt_base($home)) : (),
     );
     my $installer = App::cpm::Worker::Installer->new(%option);
     my $resolver  = App::cpm::Worker::Resolver->new(%option, impl => $option{resolver});
     bless { %option, installer => $installer, resolver => $resolver }, $class;
+}
+
+sub prebuilt_base {
+    my ($class, $home) = @_;
+    my $digest = substr Digest::MD5::md5_hex(Config->myconfig), 0, 8;
+    "$home/builds/$Config{version}-$Config{archname}-$digest";
 }
 
 sub work {

--- a/script/cpm
+++ b/script/cpm
@@ -17,6 +17,11 @@ cpm - a fast CPAN module installer
   # install modules into local/
   > cpm install Module1 Module2 ...
 
+  # install Plack, and at the same time, keep builds of CPAN distributions in ~/.perl-cpm/builds
+  > cpm install --prebuilt Plack
+  # install the prebuilts in ~/.perl-cpm/builds
+  > cd another-dir; cpm install --prebuilt Plack
+
   # install modules with verbose messages
   > cpm install -v Module
 
@@ -54,6 +59,8 @@ cpm - a fast CPAN module installer
         install modules into current @INC instead of local/
   -v, --verbose
         verbose mode; you can see what is going on
+      --prebuilt, --no-prebuilt
+        save builds for CPAN distributions; and later, install the prebuilts if available
       --target-perl=VERSION  (EXPERIMENTAL)
         install modules as if verison is your perl is VERSION
       --mirror=URL

--- a/xt/01_installer.t
+++ b/xt/01_installer.t
@@ -18,27 +18,27 @@ my $installer = App::cpm::Worker::Installer->new(
 my $mirror = "https://cpan.metacpan.org";
 my $distfile = "S/SK/SKAJI/Distribution-Metadata-0.05.tar.gz";
 my $job = { source => "cpan", uri => ["$mirror/authors/id/$distfile"], distfile => $distfile };
-my ($dir, $meta, $configure_requirements) = $installer->fetch($job);
+my $result = $installer->fetch($job);
 
-like $dir, qr{^/.*Distribution-Metadata-0\.05$}; # abs
-ok scalar(keys %$meta);
+like $result->{directory}, qr{^/.*Distribution-Metadata-0\.05$}; # abs
+ok scalar(keys %{$result->{meta}});
 
-my %reqs = map {; ($_->{package} => $_->{version_range}) } @$configure_requirements;
+my %reqs = map {; ($_->{package} => $_->{version_range}) } @{$result->{configure_requirements}};
 
 is_deeply \%reqs, {
     "ExtUtils::MakeMaker" => $] < 5.016 ? '6.58' : '0',
 };
 
-my ($distdata, $requirements) = $installer->configure({
-    directory => $dir,
+$result = $installer->configure({
+    directory => $result->{directory},
     distfile => $distfile,
-    meta => $meta,
+    meta => $result->{meta},
     source => "cpan",
 });
 
-is $distdata->{distvname}, "Distribution-Metadata-0.05";
+is $result->{distdata}{distvname}, "Distribution-Metadata-0.05";
 
-is_deeply $requirements->[-1], {
+is_deeply $result->{requirements}[-1], {
     package => "perl",
     version_range => "5.008001",
 };

--- a/xt/30_prebuilt.t
+++ b/xt/30_prebuilt.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+use Test::More;
+use Config;
+use File::Spec;
+use Path::Tiny 'path';
+use lib "xt/lib";
+use CLI;
+
+plan skip_all => 'only for perl >= 5.12' if $] < 5.012;
+
+with_same_home {
+    my $r = cpm_install "--prebuilt", "App::ChangeShebang", "File::pushd";
+    is $r->exit, 0;
+    my ($builds) = glob $r->home . "/builds/$Config{version}-$Config{archname}-*";
+    my @File_pushd = glob "$builds/DAGOLDEN/File-pushd-*";
+    my @ChangeShebang = glob "$builds/SKAJI/App-ChangeShebang-*";
+    is @File_pushd, 1;
+    is @ChangeShebang, 1;
+
+    $r = cpm_install "--prebuilt", "App::ChangeShebang", "File::pushd", "Parallel::Pipes";
+    is $r->exit, 0;
+    my $v = qr/v?[\d\.]+/;
+    like $r->err, qr/^DONE install App-ChangeShebang-$v \(using prebuilt\)$/m;
+    like $r->err, qr/^DONE install File-pushd-$v \(using prebuilt\)$/m;
+    like $r->err, qr/^DONE install Parallel-Pipes-$v$/m;
+    note $r->err;
+
+    my @Parallel_Pipes = glob "$builds/SKAJI/Parallel-Pipes-*";
+    is @Parallel_Pipes, 1;
+
+    my $packlist1 = path($r->local, "lib/perl5/$Config{archname}/auto/App/ChangeShebang/.packlist");
+    my $packlist2 = path($r->local, "lib/perl5/$Config{archname}/auto/File/pushd/.packlist");
+    my $packlist3 = path($r->local, "lib/perl5/$Config{archname}/auto/Parallel/Pipes/.packlist");
+    ok $_->is_file for $packlist1, $packlist2, $packlist3;
+
+    my @line = $packlist1->lines({chomp => 1});
+    my $expect = File::Spec->catfile($r->local, "bin/change-shebang");
+    ok !!grep { $_ eq $expect } @line;
+};
+
+done_testing;


### PR DESCRIPTION
Now cpm keeps the each builds of distributions in your home directory.
Then `cpm install` will use these prebuilt distributions.

That is, if prebuilts are available, cpm never build distributions again, just copy prebuilts into an appropriate directory.

This is (of course!) inspired by Carmel.

[![asciicast](https://asciinema.org/a/125492.png)](https://asciinema.org/a/125492?autoplay=1)