### PR TITLE
detect circular dependencies

### DIFF
--- a/lib/App/cpm.pm
+++ b/lib/App/cpm.pm
@@ -272,7 +272,8 @@ sub cmd_install {
     $master->add_job(type => "resolve", %$_) for @$packages;
     $master->add_distribution($_) for @$dists;
     $self->install($master, $worker, $self->{workers});
-    if (my $fail = $master->fail) {
+    my $fail = $master->fail;
+    if ($fail) {
         local $App::cpm::Logger::VERBOSE = 0;
         for my $type (qw(install resolve)) {
             App::cpm::Logger->log(result => "FAIL", type => $type, message => $_) for @{$fail->{$type}};
@@ -282,7 +283,7 @@ sub cmd_install {
     warn sprintf "%d distribution installed.\n", $master->installed_distributions;
     $self->cleanup;
 
-    if ($master->fail) {
+    if ($fail) {
         warn "See $self->{home}/build.log for details.\n";
         return 1;
     } else {

--- a/lib/App/cpm/CircularDependency.pm
+++ b/lib/App/cpm/CircularDependency.pm
@@ -1,0 +1,90 @@
+package App::cpm::CircularDependency;
+use strict;
+use warnings;
+our $VERSION = '0.901';
+
+{
+    package
+        App::cpm::CircularDependency::OrderedSet;
+    sub new {
+        my $class = shift;
+        bless { index => 0, hash => +{} }, $class;
+    }
+    sub add {
+        my ($self, $name) = @_;
+        $self->{hash}{$name} = $self->{index}++;
+    }
+    sub exists {
+        my ($self, $name) = @_;
+        exists $self->{hash}{$name};
+    }
+    sub values {
+        my $self = shift;
+        sort { $self->{hash}{$a} <=> $self->{hash}{$b} } keys %{$self->{hash}};
+    }
+    sub after {
+        my ($self, $name) = @_;
+        my @value = $self->values;
+        while (my $value = shift @value) {
+            if ($value eq $name) {
+                my $new = (ref $self)->new;
+                $new->add($value);
+                $new->add($_) for @value;
+                return $new;
+            }
+        }
+        return;
+    }
+}
+
+sub new {
+    my $class = shift;
+    bless {}, $class;
+}
+
+sub add {
+    my ($self, $name, $provides, $requirements) = @_;
+    $self->{$name} = +{
+        provides => [ map $_->{package}, @$provides ],
+        requirements => [ map $_->{package}, @$requirements ],
+    };
+}
+
+sub detect {
+    my $self = shift;
+
+    my %ret;
+    for my $name (sort keys %$self) {
+        my $set = App::cpm::CircularDependency::OrderedSet->new;
+        if (my $ret =  $self->_detect($name, $set)) {
+            $ret{$name} = [ $ret->values ];
+        }
+    }
+    return %ret ? \%ret : undef;
+}
+
+sub _find {
+    my ($self, $package) = @_;
+    my $found;
+    for my $name (sort keys %$self) {
+        if (grep { $_ eq $package } @{$self->{$name}{provides}}) {
+            $found = $name, last;
+        }
+    }
+    return $found;
+}
+
+sub _detect {
+    my ($self, $name, $set) = @_;
+    return $set->after($name) if $set->exists($name);
+
+    $set->add($name);
+
+    for my $requirement (grep $_, map $self->_find($_), @{ $self->{$name}{requirements} }) {
+        my $new_set = $self->_detect($requirement, $set);
+        return $new_set if $new_set;
+    }
+    return;
+}
+
+1;

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -53,12 +53,11 @@ sub fail {
     if (my $result = $detector->detect) {
         for my $distfile (sort keys %$result) {
             my $distvname = $self->distribution($distfile)->distvname;
-            App::cpm::Logger->log(result => "FAIL", type => "install", message => "$distvname, detect circular dependencies");
             push @name, $distvname;
             my @requirement = @{ $result->{$distfile} };
             my $msg = join " -> ", map { $self->distribution($_)->distvname } @requirement, $requirement[0];
             local $self->{logger}{context} = $distvname;
-            $self->{logger}->log("Circular dependencies are found: $msg");
+            $self->{logger}->log("Detected circular dependencies: $msg");
             $self->{logger}->log("Failed to install distribution");
         }
     }

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -33,7 +33,6 @@ sub new {
 
 sub fail {
     my $self = shift;
-    return $self->{_fail} if exists $self->{_fail};
 
     my @fail_resolve = sort keys %{$self->{_fail_resolve}};
     my @fail_install = sort keys %{$self->{_fail_install}};
@@ -57,13 +56,13 @@ sub fail {
             my @requirement = @{ $result->{$distfile} };
             my $msg = join " -> ", map { $self->distribution($_)->distvname } @requirement, $requirement[0];
             local $self->{logger}{context} = $distvname;
-            $self->{logger}->log("Detected circular dependencies: $msg");
+            $self->{logger}->log("Detected circular dependencies $msg");
             $self->{logger}->log("Failed to install distribution");
         }
     }
 
     push @name, map { CPAN::DistnameInfo->new($_)->distvname || $_ } @fail_install;
-    $self->{_fail} = { resolve => \@fail_resolve, install => [sort @name] };
+    { resolve => \@fail_resolve, install => [sort @name] };
 }
 
 sub jobs { values %{shift->{jobs}} }

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -2,6 +2,7 @@ package App::cpm::Master;
 use strict;
 use warnings;
 use utf8;
+use App::cpm::CircularDependency;
 use App::cpm::Distribution;
 use App::cpm::Job;
 use App::cpm::Logger;
@@ -32,11 +33,38 @@ sub new {
 
 sub fail {
     my $self = shift;
+    return $self->{_fail} if exists $self->{_fail};
+
     my @fail_resolve = sort keys %{$self->{_fail_resolve}};
     my @fail_install = sort keys %{$self->{_fail_install}};
-    return if !@fail_resolve && !@fail_install;
-    my @name = map { CPAN::DistnameInfo->new($_)->distvname || $_ } @fail_install;
-    { resolve => \@fail_resolve, install => \@name };
+    my @not_installed = grep { !$self->{_fail_install}{$_->distfile} && !$_->installed } $self->distributions;
+    return if !@fail_resolve && !@fail_install && !@not_installed;
+
+    my $detector = App::cpm::CircularDependency->new;
+    for my $dist (@not_installed) {
+        my @requirements = (
+            @{ $dist->requirements || [] },
+            @{ $dist->configure_requirements || [] },
+        );
+        $detector->add($dist->distfile, $dist->provides, \@requirements);
+    }
+
+    my @name;
+    if (my $result = $detector->detect) {
+        for my $distfile (sort keys %$result) {
+            my $distvname = $self->distribution($distfile)->distvname;
+            App::cpm::Logger->log(result => "FAIL", type => "install", message => "$distvname, detect circular dependencies");
+            push @name, $distvname;
+            my @requirement = @{ $result->{$distfile} };
+            my $msg = join " -> ", map { $self->distribution($_)->distvname } @requirement, $requirement[0];
+            local $self->{logger}{context} = $distvname;
+            $self->{logger}->log("Circular dependencies are found: $msg");
+            $self->{logger}->log("Failed to install distribution");
+        }
+    }
+
+    push @name, map { CPAN::DistnameInfo->new($_)->distvname || $_ } @fail_install;
+    $self->{_fail} = { resolve => \@fail_resolve, install => [sort @name] };
 }
 
 sub jobs { values %{shift->{jobs}} }

--- a/xt/31_circular_dep.t
+++ b/xt/31_circular_dep.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More;
+use lib "xt/lib";
+use CLI;
+
+my $r = cpm_install 'CPAN::Test::Dummy::Perl5::Make::CircDepeOne', 'File::pushd';
+isnt $r->exit, 0;
+like $r->err, qr{DONE install File-pushd};
+like $r->err, qr/FAIL install CPAN-Test-Dummy-Perl5-Make-CircDepeOne/;
+like $r->err, qr/FAIL install CPAN-Test-Dummy-Perl5-Make-CircDepeThree/;
+like $r->err, qr/FAIL install CPAN-Test-Dummy-Perl5-Make-CircDepeTwo/;
+
+like $r->err, qr/(detect circular dependencies.*){3}/sm;
+like $r->log, qr/(Circular dependencies are found.*){3}/sm;
+
+note $r->err;
+note $r->log;
+
+done_testing;

--- a/xt/31_circular_dep.t
+++ b/xt/31_circular_dep.t
@@ -11,8 +11,7 @@ like $r->err, qr/FAIL install CPAN-Test-Dummy-Perl5-Make-CircDepeOne/;
 like $r->err, qr/FAIL install CPAN-Test-Dummy-Perl5-Make-CircDepeThree/;
 like $r->err, qr/FAIL install CPAN-Test-Dummy-Perl5-Make-CircDepeTwo/;
 
-like $r->err, qr/(detect circular dependencies.*){3}/sm;
-like $r->log, qr/(Circular dependencies are found.*){3}/sm;
+like $r->log, qr/(Detected circular dependencies.*){3}/sm;
 
 note $r->err;
 note $r->log;


### PR DESCRIPTION
Fix #69 

```
❯ export PERL_CPM_PREBUILT=1 OPENSSL_INCLUDE=/usr/local/opt/openssl/include OPENSSL_LIB=/usr/local/opt/openssl/lib

❯ perl -Ilib script/cpm install Net::HTTP@6.11
DONE install Socket6-0.28 (using prebuilt)
DONE install Mozilla-CA-20160104 (using prebuilt)
DONE install Module-Build-0.4224 (using prebuilt)
DONE install IO-Socket-INET6-2.72 (using prebuilt)
DONE install Path-Class-0.37 (using prebuilt)
DONE install Try-Tiny-0.28 (using prebuilt)
DONE install URI-1.71 (using prebuilt)
DONE install Net-SSLeay-1.81 (using prebuilt)
DONE install IO-Socket-SSL-2.049 (using prebuilt)
DONE install LWP-MediaTypes-6.02 (using prebuilt)
DONE install WWW-RobotRules-6.02 (using prebuilt)
DONE install Encode-Locale-1.05 (using prebuilt)
DONE install File-Listing-6.04 (using prebuilt)
DONE install HTML-Tagset-3.20 (using prebuilt)
DONE install HTTP-Date-6.02 (using prebuilt)
DONE install HTML-Parser-3.72 (using prebuilt)
DONE install IO-HTML-1.001 (using prebuilt)
DONE install HTTP-Message-6.13 (using prebuilt)
DONE install HTTP-Daemon-6.01 (using prebuilt)
DONE install HTTP-Negotiate-6.01 (using prebuilt)
DONE install HTTP-Cookies-6.03 (using prebuilt)
FAIL install Crypt-SSLeay-0.72, detect circular dependencies
FAIL install LWP-Protocol-https-6.07, detect circular dependencies
FAIL install Net-HTTP-6.11, detect circular dependencies
FAIL install libwww-perl-6.26, detect circular dependencies
FAIL install Crypt-SSLeay-0.72
FAIL install LWP-Protocol-https-6.07
FAIL install Net-HTTP-6.11
FAIL install libwww-perl-6.26
21 distribution installed.
See /Users/skaji/.perl-cpm/build.log for details.

❯ tail /Users/skaji/.perl-cpm/build.log
2017-06-29T03:24:50,58512,HTTP-Cookies-6.03| Installing /Users/skaji/src/github.com/skaji/cpm/local/lib/perl5/darwin-2level/.meta/HTTP-Cookies-6.03/MYMETA.json
2017-06-29T03:24:50,58512,HTTP-Cookies-6.03| Successfully installed distribution
2017-06-29T03:24:50,58493,Crypt-SSLeay-0.72| Circular dependencies are found: Crypt-SSLeay-0.72 -> LWP-Protocol-https-6.07 -> libwww-perl-6.26 -> Net-HTTP-6.11 -> Crypt-SSLeay-0.72
2017-06-29T03:24:50,58493,Crypt-SSLeay-0.72| Failed to install distribution
2017-06-29T03:24:50,58493,LWP-Protocol-https-6.07| Circular dependencies are found: LWP-Protocol-https-6.07 -> libwww-perl-6.26 -> Net-HTTP-6.11 -> Crypt-SSLeay-0.72 -> LWP-Protocol-https-6.07
2017-06-29T03:24:50,58493,LWP-Protocol-https-6.07| Failed to install distribution
2017-06-29T03:24:50,58493,Net-HTTP-6.11| Circular dependencies are found: Net-HTTP-6.11 -> Crypt-SSLeay-0.72 -> LWP-Protocol-https-6.07 -> libwww-perl-6.26 -> Net-HTTP-6.11
2017-06-29T03:24:50,58493,Net-HTTP-6.11| Failed to install distribution
2017-06-29T03:24:50,58493,libwww-perl-6.26| Circular dependencies are found: libwww-perl-6.26 -> Net-HTTP-6.11 -> Crypt-SSLeay-0.72 -> LWP-Protocol-https-6.07 -> libwww-perl-6.26
2017-06-29T03:24:50,58493,libwww-perl-6.26| Failed to install distribution
```