### PR TITLE
use Win32::Console::ANSI (if available) to support color option under Win32

### DIFF
--- a/lib/App/cpm/Logger.pm
+++ b/lib/App/cpm/Logger.pm
@@ -19,6 +19,9 @@ my %color = (
     WARN => 33,
 );
 
+use constant WIN32 => $^O eq 'MSWin32';
+our $HAS_WIN32_COLOR;
+
 sub new {
     my $class = shift;
     bless {@_}, $class;
@@ -34,6 +37,13 @@ sub log {
     my $is_color = ref $self ? $self->{color} : $COLOR;
     my $verbose = ref $self ? $self->{verbose} : $VERBOSE;
     my $show_progress = ref $self ? $self->{show_progress} : $SHOW_PROGRESS;
+
+    if ($is_color and WIN32) {
+        if (!defined $HAS_WIN32_COLOR) {
+            $HAS_WIN32_COLOR = eval 'require Win32::Console::ANSI; 1' ? 1 : 0;
+        }
+        $is_color = 0 unless $HAS_WIN32_COLOR;
+    }
 
     if ($is_color) {
         $type = "\e[$color{$type}m$type\e[m" if $type && $color{$type};

--- a/lib/App/cpm/Logger.pm
+++ b/lib/App/cpm/Logger.pm
@@ -40,7 +40,7 @@ sub log {
 
     if ($is_color and WIN32) {
         if (!defined $HAS_WIN32_COLOR) {
-            $HAS_WIN32_COLOR = eval 'require Win32::Console::ANSI; 1' ? 1 : 0;
+            $HAS_WIN32_COLOR = eval { require Win32::Console::ANSI; 1 } ? 1 : 0;
         }
         $is_color = 0 unless $HAS_WIN32_COLOR;
     }


### PR DESCRIPTION
re: https://github.com/skaji/cpm/pull/98#issuecomment-313968903
With this module, you can colorize log under Win32. 
