### PR TITLE
use Pod::Text instead of Pod::Usage

### DIFF
--- a/META.json
+++ b/META.json
@@ -62,7 +62,6 @@
             "Module::CPANfile" : "0",
             "Module::Metadata" : "0",
             "Parallel::Pipes" : "0",
-            "Pod::Usage" : "1.33",
             "local::lib" : "2.000018",
             "parent" : "0",
             "perl" : "5.008001",

--- a/cpanfile
+++ b/cpanfile
@@ -17,7 +17,6 @@ requires 'Menlo';
 requires 'Module::CPANfile';
 requires 'Module::Metadata';
 requires 'Parallel::Pipes';
-requires 'Pod::Usage', '1.33'; # for perl 5.8.6 or below
 requires 'local::lib', '2.000018';
 requires 'parent';
 requires 'version', '0.77';

--- a/lib/App/cpm.pm
+++ b/lib/App/cpm.pm
@@ -12,7 +12,7 @@ use App::cpm::Resolver::Cascade;
 use Parallel::Pipes;
 use Getopt::Long qw(:config no_auto_abbrev no_ignore_case bundling);
 use List::Util ();
-use Pod::Usage ();
+use Pod::Text ();
 use File::Spec;
 use File::Path ();
 use Cwd ();
@@ -216,7 +216,11 @@ sub run {
 }
 
 sub cmd_help {
-    Pod::Usage::pod2usage(0);
+    open my $fh, ">", \my $out;
+    Pod::Text->new->parse_from_file($0, $fh);
+    $out =~ s/^[ ]{6}/    /mg;
+    print $out;
+    return 0;
 }
 
 sub cmd_version {


### PR DESCRIPTION
This reduces the size of fatpacked cpm.

before
```
❯ ls -al cpm
-rw-r--r-- 1 skaji staff 870043 Dec 30 02:50 cpm
```

after
```
❯ ls -al cpm
-rw-r--r-- 1 skaji staff 638756 Dec 30 02:55 cpm
```