### PR TITLE
support dist/url/mirror syntax in cpanfile

### DIFF
--- a/lib/App/cpm/DistNotation.pm
+++ b/lib/App/cpm/DistNotation.pm
@@ -1,0 +1,55 @@
+package App::cpm::DistNotation;
+use strict;
+use warnings;
+
+my $A1 = q{[A-Z]};
+my $A2 = q{[A-Z]{2}};
+my $AUTHOR = qr{[A-Z]{2}[\-A-Z0-9]*};
+
+our $CPAN_URI = qr{^(.*)/authors/id/($A1/$A2/$AUTHOR/.*)$}o;
+our $DISTFILE = qr{^(?:$A1/$A2/)?($AUTHOR)/(.*)$}o;
+
+sub new {
+    my $class = shift;
+    bless {
+        mirror => '',
+        distfile => '',
+    }, $class;
+}
+
+sub new_from_dist {
+    my $self = shift->new;
+    my $dist = shift;
+    if ($dist =~ $DISTFILE) {
+        my $author = $1;
+        my $rest = $2;
+        $self->{distfile} = sprintf "%s/%s/%s/%s",
+            substr($author, 0, 1), substr($author, 0, 2), $author, $rest;
+        return $self;
+    }
+    return;
+}
+
+sub new_from_uri {
+    my $self = shift->new;
+    my $uri = shift;
+    if ($uri =~ $CPAN_URI) {
+        $self->{mirror} = $1;
+        $self->{distfile} = $2;
+        return $self;
+    }
+    return;
+}
+
+sub cpan_uri {
+    my $self = shift;
+    my $mirror = shift || $self->{mirror};
+    $mirror =~ s{/+$}{};
+    sprintf "%s/authors/id/%s", $mirror, $self->{distfile};
+}
+
+sub distfile {
+    shift->{distfile};
+}
+
+1;

--- a/lib/App/cpm/Resolver/02Packages.pm
+++ b/lib/App/cpm/Resolver/02Packages.pm
@@ -2,6 +2,7 @@ package App::cpm::Resolver::02Packages;
 use strict;
 use warnings;
 use App::cpm::version;
+use App::cpm::DistNotation;
 use Cwd ();
 use File::Path ();
 our $VERSION = '0.967';
@@ -110,14 +111,13 @@ sub resolve {
             return { error => "found version $version, but it does not satisfy $version_range, @{[$self->cached_package]}" };
         }
     }
-    my $distfile = $result->{uri};
-    $distfile =~ s{^cpan:///distfile/}{};
-    $distfile =~ m{^((.).)};
-    $distfile = "$2/$1/$distfile";
+    my $uri = $result->{uri};
+    $uri =~ s{^cpan:///distfile/}{};
+    my $dist = App::cpm::DistNotation->new_from_dist($uri);
     return +{
         source => "cpan", # XXX
-        distfile => $distfile,
-        uri => "$self->{mirror}authors/id/$distfile",
+        distfile => $dist->distfile,
+        uri => $dist->cpan_uri($self->{mirror}),
         version => $result->{version} || 0,
         package => $result->{package},
     };

--- a/lib/App/cpm/Resolver/MetaCPAN.pm
+++ b/lib/App/cpm/Resolver/MetaCPAN.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use JSON::PP ();
 use HTTP::Tiny;
+use App::cpm::DistNotation;
 our $VERSION = '0.967';
 
 my $HTTP_CLIENT_CLASS = do {
@@ -52,10 +53,10 @@ sub resolve {
     }
 
     my $hash = eval { JSON::PP::decode_json($res->{content}) } or return;
-    my ($distfile) = $hash->{download_url} =~ m{/authors/id/(.+)};
+    my $dist = App::cpm::DistNotation->new_from_uri($hash->{download_url});
     return {
         source => "cpan", # XXX
-        distfile => $distfile,
+        distfile => $dist->distfile,
         package => $job->{package},
         version => $hash->{version} || 0,
         uri => $hash->{download_url},

--- a/lib/App/cpm/Resolver/MetaDB.pm
+++ b/lib/App/cpm/Resolver/MetaDB.pm
@@ -7,6 +7,7 @@ our $VERSION = '0.967';
 use HTTP::Tiny;
 use CPAN::Meta::YAML;
 use App::cpm::version;
+use App::cpm::DistNotation;
 
 sub new {
     my ($class, %option) = @_;
@@ -69,13 +70,13 @@ sub resolve {
         }
 
         if ($match) {
-            my $distfile = $match->{distfile};
+            my $dist = App::cpm::DistNotation->new_from_dist($match->{distfile});
             return {
                 source => "cpan",
                 package => $job->{package},
                 version => $match->{version},
-                uri     => [map { "${_}authors/id/$distfile" } @{$self->{mirror}}],
-                distfile => $distfile,
+                uri => [ map { $dist->cpan_uri($_) } @{$self->{mirror}} ],
+                distfile => $dist->distfile,
             };
         } else {
             return { error => "found versions @{[join ',', _uniq map $_->{version}, @found]}, but they do not satisfy $job->{version_range}, $uri" };
@@ -101,11 +102,11 @@ sub resolve {
             +{ package => $package, version => $version };
         } sort keys %{$meta->{provides}};
 
-        my $distfile = $meta->{distfile};
+        my $dist = App::cpm::DistNotation->new_from_dist($meta->{distfile});
         return {
             source => "cpan",
-            distfile => $distfile,
-            uri => [map { "${_}authors/id/$distfile" } @{$self->{mirror}}],
+            distfile => $dist->distfile,
+            uri => [ map { $dist->cpan_uri($_) } @{$self->{mirror}} ],
             version  => $meta->{version},
             provides => \@provides,
         };

--- a/lib/App/cpm/Resolver/Snapshot.pm
+++ b/lib/App/cpm/Resolver/Snapshot.pm
@@ -2,6 +2,7 @@ package App::cpm::Resolver::Snapshot;
 use strict;
 use warnings;
 use App::cpm::version;
+use App::cpm::DistNotation;
 use Carton::Snapshot;
 our $VERSION = '0.967';
 
@@ -41,11 +42,11 @@ sub resolve {
         +{ package => $package, version => $version };
     } sort keys %{$found->provides};
 
-    my $distfile = $found->distfile;
+    my $dist = App::cpm::DistNotation->new_from_dist($found->distfile);
     return {
         source => "cpan",
-        distfile => $distfile,
-        uri => [map { "${_}authors/id/$distfile" } @{$self->{mirror}}],
+        distfile => $dist->distfile,
+        uri => [map { $dist->cpan_uri($_) } @{$self->{mirror}}],
         version  => $version || 0,
         provides => \@provides,
     };

--- a/lib/App/cpm/Tutorial.pm
+++ b/lib/App/cpm/Tutorial.pm
@@ -71,7 +71,7 @@ And cpm can install modules from git repositories directly.
 
   $ cpm install git://github.com/skaji/Carl.git
 
-=head2 cpanfile and experimental git/dist syntax
+=head2 cpanfile and dist/url/mirror/git syntax
 
 If you omit arguments, and there exists C<cpanfile> in the current directory,
 then cpm loads modules from cpanfile, and install them
@@ -81,24 +81,36 @@ then cpm loads modules from cpanfile, and install them
   requires 'Plack', '> 1.000, <= 2.000';
   $ cpm install
 
-Moreover if you have C<cpanfile.snapshot>,
+If you have C<cpanfile.snapshot>,
 then cpm tries to resolve distribution names from it
 
   $ cpm install -v
   30186 DONE resolve (0.001sec) Plack -> Plack-1.0030 (from Snapshot)
   ...
 
-This is an experimental and fun part! cpm supports git/dist syntax in cpanfile.
+cpm supports dist/url/mirror syntax in cpanfile just like cpanminus:
 
-  $ cat cpanfile
+  requires 'Path::Class', 0.26,
+    dist => "KWILLIAMS/Path-Class-0.26.tar.gz";
+
+  # use dist + mirror
+  requires 'Cookie::Baker',
+    dist => "KAZEBURO/Cookie-Baker-0.08.tar.gz",
+    mirror => "http://cpan.cpantesters.org/";
+
+  # use the full URL
+  requires 'Try::Tiny', 0.28,
+    url => "http://backpan.perl.org/authors/id/E/ET/ETHER/Try-Tiny-0.28.tar.gz";
+
+And yes, this is an experimental and fun part! cpm also supports git syntax in cpanfile.
+
   requires 'Carl', git => 'git://github.com/skaji/Carl.git';
-  requires 'Plack', git => 'ssh://git@github.com/plack/Plack.git';
   requires 'App::cpm', git => 'https://login:password@github.com/skaji/cpm.git';
   requires 'Perl::PrereqDistributionGatherer',
     git => 'https://github.com/skaji/Perl-PrereqDistributionGatherer',
     ref => '3850305'; # ref can be revision/branch/tag
 
-Please note that to support git/dist syntax in cpanfile wholly,
+Please note that to support git syntax in cpanfile wholly,
 there are several TODOs.
 
 =head2 Darkpan integration

--- a/xt/17_cpanfile.t
+++ b/xt/17_cpanfile.t
@@ -25,4 +25,51 @@ my $content = $file->slurp_raw;
 my $want = q{our $VERSION = '0.05';};
 like $content, qr{\Q$want};
 
+
+
+$cpanfile->spew(<<'___');
+requires 'Path::Class', 0.26,
+  dist => "KWILLIAMS/Path-Class-0.26.tar.gz";
+
+# omit version specifier
+requires 'Hash::MultiValue',
+  dist => "MIYAGAWA/Hash-MultiValue-0.15.tar.gz";
+
+# use dist + mirror
+requires 'Cookie::Baker',
+  dist => "KAZEBURO/Cookie-Baker-0.08.tar.gz",
+  mirror => "http://cpan.cpantesters.org/";
+
+# use the full URL
+requires 'Try::Tiny', 0.28,
+  url => "http://backpan.perl.org/authors/id/E/ET/ETHER/Try-Tiny-0.28.tar.gz";
+___
+
+$r = cpm_install "--cpanfile", "$cpanfile";
+is $r->exit, 0;
+
+like $r->log, qr/Hash-MultiValue-0\.15\| Successfully installed distribution/;
+like $r->log, qr/Path-Class-0\.26\| Successfully installed distribution/;
+like $r->log, qr/Cookie-Baker-0\.08\| Successfully installed distribution/;
+like $r->log, qr!Fetching \Qhttp://cpan.cpantesters.org/authors/id/K/KA/KAZEBURO/Cookie-Baker-0.08.tar.gz\E!;
+like $r->log, qr/Try-Tiny-0\.28\| Successfully installed distribution/;
+like $r->log, qr!Fetching \Qhttp://backpan.perl.org/authors/id/E/ET/ETHER/Try-Tiny-0.28.tar.gz\E!;
+
+$cpanfile->spew(<<'___');
+requires 'Path::Class', 0.26,
+  url => "KWILLIAMS/Path-Class-0.26.tar.gz";
+___
+$r = cpm_install "--cpanfile", "$cpanfile";
+isnt $r->exit, 0;
+note $r->err;
+
+$cpanfile->spew(<<'___');
+requires 'Try::Tiny', 0.28,
+  dist => "http://backpan.perl.org/authors/id/E/ET/ETHER/Try-Tiny-0.28.tar.gz";
+___
+$r = cpm_install "--cpanfile", "$cpanfile";
+isnt $r->exit, 0;
+note $r->err;
+
+
 done_testing;


### PR DESCRIPTION
Follow https://github.com/miyagawa/cpanminus/pull/568

Now cpm also supports dist/url/mirror syntax in cpanfile
```perl
requires 'Path::Class', 0.26,
  dist => "KWILLIAMS/Path-Class-0.26.tar.gz";

# omit version specifier
requires 'Hash::MultiValue',
  dist => "MIYAGAWA/Hash-MultiValue-0.15.tar.gz";

# use dist + mirror
requires 'Cookie::Baker',
  dist => "KAZEBURO/Cookie-Baker-0.08.tar.gz",
  mirror => "http://cpan.cpantesters.org/";

# use the full URL
requires 'Try::Tiny', 0.28,
  url => "http://backpan.perl.org/authors/id/E/ET/ETHER/Try-Tiny-0.28.tar.gz";
```