### PR TITLE
Use Sys::Info to determine how many workers to use

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -18,6 +18,7 @@ requires 'Menlo::CLI::Compat', '1.9021';
 requires 'Module::CPANfile';
 requires 'Module::Metadata';
 requires 'Parallel::Pipes', '0.004';
+requires 'Sys::Info', '0.78';
 requires 'local::lib', '2.000018';
 requires 'parent';
 requires 'version', '0.77';


### PR DESCRIPTION
Use Sys::Info to attempt to figure out how many CPU's are available, and
use that as the number of workers by default.  If the number of CPUs
cannot be determined, fallback to using the previous numbers (1 for
WIN32, 5 everywhere else).