### PR TITLE
Improve installation from git sources

### DIFF
--- a/lib/App/cpm/Distribution.pm
+++ b/lib/App/cpm/Distribution.pm
@@ -32,7 +32,7 @@ for my $attr (qw(
     uri
     provides
     requirements
-    ref
+    rev
     static_builder
     prebuilt
 )) {
@@ -51,9 +51,16 @@ sub distfile {
 
 sub distvname {
     my $self = shift;
+    $self->{distvname} = shift if @_;
     $self->{distvname} ||= do {
         CPAN::DistnameInfo->new($self->{distfile})->distvname || $self->distfile;
     };
+}
+
+sub version {
+    my $self = shift;
+    $self->{version} = shift if @_;
+    $self->{version} ||= CPAN::DistnameInfo->new($self->{distfile})->version || 0;
 }
 
 sub overwrite_provide {

--- a/lib/App/cpm/Git.pm
+++ b/lib/App/cpm/Git.pm
@@ -39,7 +39,8 @@ sub rev_is {
 sub version {
     my ($class, $dir) = @_;
     my $guard = pushd $dir;
-    chomp(my $version = `git describe --tags --match '*.*' 2>/dev/null`);
+    my $devnull = File::Spec->devnull;
+    chomp(my $version = `git describe --tags --match "*.*" 2>$devnull`);
     if ($version) {
         if ($version =~ /^(\d+\.\d+)(?:-(\d+)-g\p{IsXDigit}+)?$/) {
             $version = $1 . ($2 ? sprintf "_%02d", $2 : '');

--- a/lib/App/cpm/Git.pm
+++ b/lib/App/cpm/Git.pm
@@ -1,0 +1,87 @@
+package App::cpm::Git;
+use strict;
+use warnings;
+
+use CPAN::Meta;
+use File::Find ();
+use File::Spec;
+
+sub is_git_uri {
+    my ($class, $uri) = @_;
+    return $uri =~ /(?:^git:|\.git(?:@|\/|$))/;
+}
+
+sub split_uri {
+    my ($class, $uri) = @_;
+    $uri =~ s/(?<=\.git)(\/.+)$//;
+    return ($uri, $1);
+}
+
+sub module_rev {
+    my ($class, $filename) = @_;
+    open my $f, '<', $filename or return;
+    while (my $line = <$f>) {
+        if ($line =~ /VERSION.*# (\p{IsXDigit}{40})$/) {
+            close $f;
+            return $1;
+        }
+    }
+    close $f;
+    return;
+}
+
+sub rev_is {
+    my ($class, $short_rev, $long_rev) = @_;
+    return $long_rev && index($long_rev, $short_rev) == 0;
+}
+
+sub version {
+    my ($class, $dir) = @_;
+    chomp(my $version = `git -C $dir describe --tags --match '*.*' 2>/dev/null`);
+    if ($version) {
+        if ($version =~ /^(\d+\.\d+)(?:-(\d+)-g\p{IsXDigit}+)?$/) {
+            $version = $1 . ($2 ? sprintf "_%02d", $2 : '');
+        } elsif ($version =~ /^v(\d+\.\d+)(?:-(\d+)-g\p{IsXDigit}+)?$/) {
+            $version = "v$1.0" . ($2 ? ".$2" : '');
+        } elsif ($version =~ /^v?(\d+\.\d+\.\d+)(?:-(\d+)-g\p{IsXDigit}+)?$/) {
+            $version = "v$1" . ($2 ? ".$2" : '');
+        } else {
+            $version = undef;
+        }
+    }
+    unless ($version) {
+        chomp(my $time = `git -C $dir show -s --pretty=format:%at`);
+        $version = sprintf "0.000_%09d", $time / 4; # divide by 4 to fit MAX_INT32 into 3 triples
+    }
+    return $version;
+}
+
+sub rewrite_version {
+    my ($class, $dir, $version, $rev) = @_;
+
+    foreach my $file (map File::Spec->catfile($dir, $_), 'META.json', 'META.yml') {
+        next unless -f $file;
+        my $meta = CPAN::Meta->load_file($file);
+        $meta->{version} = $version;
+        $meta->save($file);
+    }
+
+    File::Find::find(sub {
+        return unless $_ =~ /\.pm$/;
+        my $content = do {
+            open my $f, '<', $_ or return;
+            local $/ = undef;
+            my $c = <$f>;
+            close $f;
+            $c;
+        };
+        $content =~ s/([\$*][\w\:\']*\bVERSION\b\s*=\s*)[^;]+;\n?/$1'$version'; # $rev\n/mso
+            or $content =~ s/^(package[^;]+;)\n?/$1\nour \$VERSION = '$version'; # $rev\n/msg
+            or return;
+        open my $f, '>', $_ or return;
+        print $f $content;
+        close $f;
+    }, $dir);
+}
+
+1;

--- a/lib/App/cpm/Git.pm
+++ b/lib/App/cpm/Git.pm
@@ -4,6 +4,7 @@ use warnings;
 
 use CPAN::Meta;
 use File::Find ();
+use File::pushd 'pushd';
 use File::Spec;
 
 sub is_git_uri {
@@ -37,7 +38,8 @@ sub rev_is {
 
 sub version {
     my ($class, $dir) = @_;
-    chomp(my $version = `git -C $dir describe --tags --match '*.*' 2>/dev/null`);
+    my $guard = pushd $dir;
+    chomp(my $version = `git describe --tags --match '*.*' 2>/dev/null`);
     if ($version) {
         if ($version =~ /^(\d+\.\d+)(?:-(\d+)-g\p{IsXDigit}+)?$/) {
             $version = $1 . ($2 ? sprintf "_%02d", $2 : '');
@@ -50,7 +52,7 @@ sub version {
         }
     }
     unless ($version) {
-        chomp(my $time = `git -C $dir show -s --pretty=format:%at`);
+        chomp(my $time = `git show -s --pretty=format:%at`);
         $version = sprintf "0.000_%09d", $time / 4; # divide by 4 to fit MAX_INT32 into 3 triples
     }
     return $version;

--- a/lib/App/cpm/Job.pm
+++ b/lib/App/cpm/Job.pm
@@ -31,11 +31,13 @@ sub distfile {
 
 sub distvname {
     my $self = shift;
-    return $self->{_distvname} if $self->{_distvname};
+    return $self->{distvname} if $self->{distvname};
     if ($self->{distfile}) {
-        $self->{_distvname} ||= CPAN::DistnameInfo->new($self->{distfile})->distvname;
-    } elsif ($self->{uri}[0]) {
+        $self->{distvname} ||= CPAN::DistnameInfo->new($self->{distfile})->distvname;
+    } elsif (ref $self->{uri} eq 'ARRAY' && $self->{uri}[0]) {
         $self->{uri}[0];
+    } elsif (!ref $self->{uri} && $self->{uri}) {
+        $self->{uri};
     } elsif ($self->{package}) {
         $self->{package};
     } else {

--- a/lib/App/cpm/Resolver/CPANfile.pm
+++ b/lib/App/cpm/Resolver/CPANfile.pm
@@ -44,6 +44,7 @@ sub _load {
                 uri => $uri,
                 ref => $option->{ref},
                 provides => [{package => $package}],
+                next => 1,
             };
         } elsif ($uri = $option->{dist}) {
             my $dist = App::cpm::DistNotation->new_from_dist($uri);

--- a/lib/App/cpm/Resolver/Cascade.pm
+++ b/lib/App/cpm/Resolver/Cascade.pm
@@ -26,6 +26,8 @@ sub resolve {
         $klass = $1 if $klass =~ /^App::cpm::Resolver::(.*)$/;
         if (my $error = $result->{error}) {
             push @error, "$klass, $error";
+        } elsif ($result->{next}) {
+            $job->{$_} = $result->{$_} foreach grep { $_ ne 'next' } keys %$result;
         } else {
             $result->{from} = $klass;
             return $result;

--- a/lib/App/cpm/Resolver/Git.pm
+++ b/lib/App/cpm/Resolver/Git.pm
@@ -1,0 +1,64 @@
+package App::cpm::Resolver::Git;
+use strict;
+use warnings;
+use App::cpm::Git;
+use App::cpm::version;
+
+sub new {
+    my ($class) = @_;
+    return bless {}, $class;
+}
+
+sub fetch_rev {
+    my ($class, $uri, $ref) = @_;
+    return unless $ref;
+
+    ($uri) = App::cpm::Git->split_uri($uri);
+    my ($rev, $version) = `git ls-remote --refs $uri $ref` =~ /^(\p{IsXDigit}{40})\s+(?:refs\/tags\/(v?\d+\.\d+(?:\.\d+)?)$)?/;
+    $rev = $ref if !$rev && $ref =~ /^[0-9a-fA-F]{4,}$/;
+    return ($rev, $version);
+}
+
+sub resolve {
+    my ($self, $job) = @_;
+    return unless $job->{source} && $job->{source} eq 'git';
+
+    my ($rev, $version);
+    if ($job->{ref}) {
+        ($rev, $version) = $self->fetch_rev($job->{uri}, $job->{ref});
+    } else {
+        my @tags;
+        my ($uri) = App::cpm::Git->split_uri($job->{uri});
+        my $out = `git ls-remote --tags --refs $uri '*.*'`;
+        while ($out =~ /^(\p{IsXDigit}{40})\s+refs\/tags\/(.+)$/mg) {
+            my ($r, $v) = ($1, $2);
+            push @tags, {
+                version => App::cpm::version->parse($v),
+                rev     => $r,
+            };
+        }
+        if (@tags) {
+            foreach my $tag (sort { $b->{version} <=> $a->{version} } @tags) {
+                if ($tag->{version}->satisfy($job->{version_range})) {
+                    $version = $tag->{version}->stringify;
+                    $rev = $tag->{rev};
+                    last;
+                }
+            }
+        } else {
+            ($rev) = `git ls-remote $uri HEAD` =~ /^(\p{IsXDigit}+)\s/;
+        }
+    }
+    return { error => 'repo or ref not found' } unless $rev;
+
+    return {
+        source => 'git',
+        uri => $job->{uri},
+        ref => $job->{ref},
+        rev => $rev,
+        package => $job->{package},
+        version => $version,
+    };
+}
+
+1;

--- a/lib/App/cpm/Resolver/Git.pm
+++ b/lib/App/cpm/Resolver/Git.pm
@@ -29,7 +29,7 @@ sub resolve {
     } else {
         my @tags;
         my ($uri) = App::cpm::Git->split_uri($job->{uri});
-        my $out = `git ls-remote --tags --refs $uri '*.*'`;
+        my $out = `git ls-remote --tags --refs $uri "*.*"`;
         while ($out =~ /^(\p{IsXDigit}{40})\s+refs\/tags\/(.+)$/mg) {
             my ($r, $v) = ($1, $2);
             push @tags, {

--- a/lib/App/cpm/Tutorial.pm
+++ b/lib/App/cpm/Tutorial.pm
@@ -109,6 +109,16 @@ And yes, this is an experimental and fun part! cpm also supports git syntax in c
   requires 'Perl::PrereqDistributionGatherer',
     git => 'https://github.com/skaji/Perl-PrereqDistributionGatherer',
     ref => '3850305'; # ref can be revision/branch/tag
+  requires 'Menlo', '>= 1.9020, < 2.0000' # version ranges are mapped to tags
+    git => 'https://github.com/miyagawa/cpanminus.git/Menlo'; # from subdirectory of git repo
+
+Nothing is required to make git repository installable: C<META.json>, C<cpanfile>,
+C<Makefile.PL> and C<Build.PL> are optional. Distribution name can be extracted from
+repository name if none of C<META.json>, C<Makefile.PL> and C<Build.PL> exist.
+Version is always calculated from the nearest git tag and forced to the installed files.
+
+Git dependencies can be saved to C<cpanfile.snapshot> (using git uri and revision as a key)
+and resolved from it.
 
 Please note that to support git syntax in cpanfile wholly,
 there are several TODOs.

--- a/xt/13_git.t
+++ b/xt/13_git.t
@@ -16,6 +16,41 @@ subtest git2 => sub {
     note $r->err;
 };
 
+subtest git_subdir => sub {
+    my $r = cpm_install 'https://github.com/miyagawa/cpanminus.git/Menlo@1.9019';
+    is $r->exit, 0;
+    like $r->err, qr{DONE install Menlo-1.9019 \(https://github.com/miyagawa/cpanminus.git/Menlo\@74d7997c2b35b1bfb964530e2675773ca54b581e\)};
+    note $r->err;
+};
+
+subtest git_describe => sub {
+    my $r = cpm_install 'https://github.com/skaji/change-shebang.git@6eadaaa';
+    is $r->exit, 0;
+    like $r->err, qr{DONE install App-ChangeShebang-0.05_02 \(https://github.com/skaji/change-shebang.git\@6eadaaaadf79ea9a90b1a4d995af794b9133d634\)};
+    note $r->err;
+};
+
+subtest git_notags => sub {
+    my $r = cpm_install 'https://github.com/skaji/change-shebang.git@92651ea';
+    is $r->exit, 0;
+    like $r->err, qr{DONE install App-ChangeShebang-0.000_351143984 \(https://github.com/skaji/change-shebang.git\@92651ea73c26191f0c6934dcfed1e4e5f181b1b4\)};
+    note $r->err;
+};
+
+subtest git_nometa => sub {
+    my $r = cpm_install 'https://github.com/my-mail-ru/perl-AnyEvent-HTTP-ProxyChain.git@1.02';
+    is $r->exit, 0;
+    like $r->err, qr{DONE install AnyEvent-HTTP-ProxyChain-1.02 \(https://github.com/my-mail-ru/perl-AnyEvent-HTTP-ProxyChain.git\@b584eb9747a061a525044fd95ed42cf64ec7826c\)};
+    note $r->err;
+};
+
+subtest git_libonly => sub {
+    my $r = cpm_install 'https://github.com/my-mail-ru/perl-MR-Rest.git@2119a95';
+    is $r->exit, 0;
+    like $r->err, qr{DONE install MR-Rest-0.000_353848525 \(https://github.com/my-mail-ru/perl-MR-Rest.git\@2119a95aefe609113b0adcfc006569b2da109870\)};
+    note $r->err;
+};
+
 subtest fail => sub {
     my $r = cpm_install "-v", "git://github.com/skaji/xxxxx.git";
     isnt $r->exit, 0;

--- a/xt/13_git.t
+++ b/xt/13_git.t
@@ -45,6 +45,7 @@ subtest git_nometa => sub {
 };
 
 subtest git_libonly => sub {
+    plan skip_all => "only for perl 5.12+" if $] < 5.012;
     my $r = cpm_install 'https://github.com/my-mail-ru/perl-MR-Rest.git@2119a95';
     is $r->exit, 0;
     like $r->err, qr{DONE install MR-Rest-0.000_353848525 \(https://github.com/my-mail-ru/perl-MR-Rest.git\@2119a95aefe609113b0adcfc006569b2da109870\)};

--- a/xt/17_cpanfile.t
+++ b/xt/17_cpanfile.t
@@ -21,27 +21,59 @@ with_same_local {
     is $r->exit, 0 or diag $r->err;
     like $r->err, qr/DONE install CPAN-Mirror-Tiny-0.04/;
     like $r->err, qr/DONE install HTTP-Tinyish-0.06/;
-    like $r->err, qr{DONE install https://github.com/skaji/change-shebang};
+    like $r->err, qr{DONE install App-ChangeShebang-0.05 \(https://github.com/skaji/change-shebang\@4d2de546e80c29b74afd1e8dadb301b004e020cb\)};
     like $r->err, qr/DONE install Try-Tiny-0.30/;
     like $r->log, qr/Resolved CPAN::Mirror::Tiny.*from MetaDB/;
     like $r->log, qr/Resolved HTTP::Tinyish.*from MetaDB/;
-    like $r->log, qr/Resolved App::ChangeShebang.*from CPANfile/;
+    like $r->log, qr/Resolved App::ChangeShebang.*from Git/;
     like $r->log, qr/Resolved Try::Tiny.*from CPANfile/;
     note $r->err;
     my $file = path($r->local, "lib/perl5/App/ChangeShebang.pm");
     my $content = $file->slurp_raw;
-    my $want = q{our $VERSION = '0.05';};
+    my $want = q{our $VERSION = '0.05'; # 4d2de546e80c29b74afd1e8dadb301b004e020cb};
     like $content, qr{\Q$want};
 
     # 2nd time; only install git
     $r = cpm_install "--cpanfile", "$cpanfile";
     is $r->exit, 0;
-    like $r->err, qr{DONE install https://github.com/skaji/change-shebang};
+    like $r->err, qr/DONE install App::ChangeShebang is up to date\. \(0\.05\)/;
     unlike $r->err, qr/CPAN-Mirror-Tiny/;
     unlike $r->err, qr/HTTP-Tinyish/;
     unlike $r->err, qr/Try-Tiny/;
 };
 
+
+$cpanfile->spew(<<'___');
+requires 'CPAN::Mirror::Tiny', '< 0.05';
+requires 'HTTP::Tinyish', '== 0.06';
+requires 'App::ChangeShebang', '== 0.05',
+    git => 'https://github.com/skaji/change-shebang';
+requires 'Try::Tiny',
+    url => 'https://cpan.metacpan.org/authors/id/E/ET/ETHER/Try-Tiny-0.30.tar.gz';
+___
+
+with_same_local {
+    my $r = cpm_install "--cpanfile", "$cpanfile";
+    is $r->exit, 0 or diag $r->err;
+    like $r->err, qr/DONE install CPAN-Mirror-Tiny-0.04/;
+    like $r->err, qr/DONE install HTTP-Tinyish-0.06/;
+    like $r->err, qr{DONE install App-ChangeShebang-0.05 \(https://github.com/skaji/change-shebang\@4d2de546e80c29b74afd1e8dadb301b004e020cb\)};
+    like $r->err, qr/DONE install Try-Tiny-0.30/;
+    like $r->log, qr/Resolved CPAN::Mirror::Tiny.*from MetaDB/;
+    like $r->log, qr/Resolved HTTP::Tinyish.*from MetaDB/;
+    like $r->log, qr/Resolved App::ChangeShebang.*from Git/;
+    like $r->log, qr/Resolved Try::Tiny.*from CPANfile/;
+    note $r->err;
+    my $file = path($r->local, "lib/perl5/App/ChangeShebang.pm");
+    my $content = $file->slurp_raw;
+    my $want = q{our $VERSION = '0.05'; # 4d2de546e80c29b74afd1e8dadb301b004e020cb};
+    like $content, qr{\Q$want};
+
+    # 2nd time; only install git
+    $r = cpm_install "--cpanfile", "$cpanfile";
+    is $r->exit, 0;
+    like $r->err, qr/All requirements are satisfied/;
+};
 
 
 $cpanfile->spew(<<'___');


### PR DESCRIPTION
* Resolve ref to rev at the resolve stage and use only rev as
  a more stable key on the next stages.
* Store git dependencies to cpanfile.snapshot using git uri
  and revision as a key, resolve exact revision from snapshot.
* Ability to install git distributions which don't contain
  META.json and even Makefile.PL and Build.PL (static install).
* Use git tags as versions, extract version from the nearest tag,
  write it to the installed files.
* Abilty to select last tag conforming to version range from
  the tags list.
* Cache cloned git repositories and prebuilt git packages.
* Merge cpanfile into MYMETA.json and MYMETA.yml if no
  META.json and META.yml provided in distribution.