### PR TITLE
check if dependencies in core INC are actually core

### DIFF
--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -30,6 +30,18 @@ sub new {
             die "Module::CoreList does not have our perl $] entry, abort.\n";
         }
     }
+    if (!$self->{global}) {
+        if (eval { require Module::CoreList }) {
+            if (!exists $Module::CoreList::version{$]}) {
+                die "Module::CoreList does not have our perl $] entry, abort.\n";
+            }
+            $self->{_has_corelist} = 1;
+        } else {
+            my $msg = "You don't have Module::CoreList. "
+                    . "The local-lib may result in incomplete self-contained directory.";
+            App::cpm::Logger->log(result => "WARN", message => $msg);
+        }
+    }
     $self;
 }
 
@@ -284,12 +296,25 @@ sub is_installed {
             return $wantarray ? (1, $self->{_is_installed}{$package}) : 1;
         }
     }
-    my $info = Module::Metadata->new_from_module($package, inc => $self->{inc});
+    my $info = Module::Metadata->new_from_module($package, inc => $self->{search_inc});
     return unless $info;
+
+    if (!$self->{global} and $self->{_has_corelist} and $self->_in_core_inc($info->filename)) {
+        # https://github.com/miyagawa/cpanminus/blob/7b574ede70cebce3709743ec1727f90d745e8580/Menlo-Legacy/lib/Menlo/CLI/Compat.pm#L1783-L1786
+        # if found package in core inc,
+        # but it does not list in CoreList,
+        # we should treat it as not being installed
+        return if !exists $Module::CoreList::version{$]}{$info->name};
+    }
     my $current_version = $self->{_is_installed}{$package}
                         = App::cpm::version->parse($info->version);
     my $ok = $current_version->satisfy($version_range);
     $wantarray ? ($ok, $current_version) : $ok;
+}
+
+sub _in_core_inc {
+    my ($self, $file) = @_;
+    !!grep { $file =~ /^\Q$_/ } @{$self->{core_inc}};
 }
 
 sub is_core {

--- a/xt/21_resolver_option.t
+++ b/xt/21_resolver_option.t
@@ -26,64 +26,46 @@ subtest snapshot => sub {
     $snapshot->spew(<<'...');
 # carton snapshot format: version 1.0
 DISTRIBUTIONS
-  ExtUtils-MakeMaker-7.24
-    pathname: B/BI/BINGOS/ExtUtils-MakeMaker-7.24.tar.gz
+  ExtUtils-CBuilder-0.280231
+    pathname: A/AM/AMBS/ExtUtils-CBuilder-0.280231.tar.gz
     provides:
-      ExtUtils::Command 7.24
-      ExtUtils::Command::MM 7.24
-      ExtUtils::Liblist 7.24
-      ExtUtils::Liblist::Kid 7.24
-      ExtUtils::MM 7.24
-      ExtUtils::MM_AIX 7.24
-      ExtUtils::MM_Any 7.24
-      ExtUtils::MM_BeOS 7.24
-      ExtUtils::MM_Cygwin 7.24
-      ExtUtils::MM_DOS 7.24
-      ExtUtils::MM_Darwin 7.24
-      ExtUtils::MM_MacOS 7.24
-      ExtUtils::MM_NW5 7.24
-      ExtUtils::MM_OS2 7.24
-      ExtUtils::MM_QNX 7.24
-      ExtUtils::MM_UWIN 7.24
-      ExtUtils::MM_Unix 7.24
-      ExtUtils::MM_VMS 7.24
-      ExtUtils::MM_VOS 7.24
-      ExtUtils::MM_Win32 7.24
-      ExtUtils::MM_Win95 7.24
-      ExtUtils::MY 7.24
-      ExtUtils::MakeMaker 7.24
-      ExtUtils::MakeMaker::Config 7.24
-      ExtUtils::MakeMaker::Locale 7.24
-      ExtUtils::MakeMaker::_version 7.24
-      ExtUtils::MakeMaker::charstar 7.24
-      ExtUtils::MakeMaker::version 7.24
-      ExtUtils::MakeMaker::version::regex 7.24
-      ExtUtils::MakeMaker::version::vpp 7.24
-      ExtUtils::Mkbootstrap 7.24
-      ExtUtils::Mksymlists 7.24
-      ExtUtils::testlib 7.24
-      MM 7.24
-      MY 7.24
+      ExtUtils::CBuilder 0.280231
+      ExtUtils::CBuilder::Base 0.280231
+      ExtUtils::CBuilder::Platform::Unix 0.280231
+      ExtUtils::CBuilder::Platform::VMS 0.280231
+      ExtUtils::CBuilder::Platform::Windows 0.280231
+      ExtUtils::CBuilder::Platform::Windows::BCC 0.280231
+      ExtUtils::CBuilder::Platform::Windows::GCC 0.280231
+      ExtUtils::CBuilder::Platform::Windows::MSVC 0.280231
+      ExtUtils::CBuilder::Platform::aix 0.280231
+      ExtUtils::CBuilder::Platform::android 0.280231
+      ExtUtils::CBuilder::Platform::cygwin 0.280231
+      ExtUtils::CBuilder::Platform::darwin 0.280231
+      ExtUtils::CBuilder::Platform::dec_osf 0.280231
+      ExtUtils::CBuilder::Platform::os2 0.280231
     requirements:
-      Data::Dumper 0
-      Encode 0
+      Cwd 0
+      ExtUtils::MakeMaker 6.30
       File::Basename 0
-      File::Spec 0.8
-      Pod::Man 0
-      perl 5.006
-  ExtUtils-ParseXS-3.30
-    pathname: S/SM/SMUELLER/ExtUtils-ParseXS-3.30.tar.gz
+      File::Spec 3.13
+      File::Temp 0
+      IO::File 0
+      IPC::Cmd 0
+      Perl::OSType 1
+      Text::ParseWords 0
+  ExtUtils-ParseXS-3.35
+    pathname: S/SM/SMUELLER/ExtUtils-ParseXS-3.35.tar.gz
     provides:
-      ExtUtils::ParseXS 3.30
-      ExtUtils::ParseXS::Constants 3.30
-      ExtUtils::ParseXS::CountLines 3.30
-      ExtUtils::ParseXS::Eval 3.30
-      ExtUtils::ParseXS::Utilities 3.30
-      ExtUtils::Typemaps 3.30
-      ExtUtils::Typemaps::Cmd 3.30
-      ExtUtils::Typemaps::InputMap 3.30
-      ExtUtils::Typemaps::OutputMap 3.30
-      ExtUtils::Typemaps::Type 3.30
+      ExtUtils::ParseXS 3.35
+      ExtUtils::ParseXS::Constants 3.35
+      ExtUtils::ParseXS::CountLines 3.35
+      ExtUtils::ParseXS::Eval 3.35
+      ExtUtils::ParseXS::Utilities 3.35
+      ExtUtils::Typemaps 3.35
+      ExtUtils::Typemaps::Cmd 3.35
+      ExtUtils::Typemaps::InputMap 3.35
+      ExtUtils::Typemaps::OutputMap 3.35
+      ExtUtils::Typemaps::Type 3.35
     requirements:
       Carp 0
       Cwd 0
@@ -95,12 +77,102 @@ DISTRIBUTIONS
       File::Spec 0
       Symbol 0
       Test::More 0.47
+  IPC-Cmd-1.02
+    pathname: B/BI/BINGOS/IPC-Cmd-1.02.tar.gz
+    provides:
+      IPC::Cmd 1.02
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      File::Temp 0
+      Locale::Maketext::Simple 0
+      Module::Load::Conditional 0.66
+      Params::Check 0.20
+      Test::More 0
+  Locale-Maketext-Simple-0.21
+    pathname: J/JE/JESSE/Locale-Maketext-Simple-0.21.tar.gz
+    provides:
+      Locale::Maketext::Simple 0.21
+    requirements:
+      ExtUtils::MakeMaker 0
+  Module-CoreList-5.20190420
+    pathname: B/BI/BINGOS/Module-CoreList-5.20190420.tar.gz
+    provides:
+      Module::CoreList 5.20190420
+      Module::CoreList::Utils 5.20190420
+    requirements:
+      ExtUtils::MakeMaker 0
+      List::Util 0
+      Test::More 0
+      version 0.88
+  Module-Load-0.34
+    pathname: B/BI/BINGOS/Module-Load-0.34.tar.gz
+    provides:
+      Module::Load 0.34
+    requirements:
+      ExtUtils::MakeMaker 0
+      Test::More 0.94
+  Module-Load-Conditional-0.68
+    pathname: B/BI/BINGOS/Module-Load-Conditional-0.68.tar.gz
+    provides:
+      Module::Load::Conditional 0.68
+    requirements:
+      ExtUtils::MakeMaker 0
+      Locale::Maketext::Simple 0
+      Module::CoreList 2.22
+      Module::Load 0.28
+      Module::Metadata 1.000005
+      Params::Check 0
+      Test::More 0
+      version 0.69
+  Module-Metadata-1.000036
+    pathname: E/ET/ETHER/Module-Metadata-1.000036.tar.gz
+    provides:
+      Module::Metadata 1.000036
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
+      Fcntl 0
+      File::Find 0
+      File::Spec 0
+      perl 5.006
+      strict 0
+      version 0.87
+      warnings 0
+  Params-Check-0.38
+    pathname: B/BI/BINGOS/Params-Check-0.38.tar.gz
+    provides:
+      Params::Check 0.38
+    requirements:
+      ExtUtils::MakeMaker 0
+      Locale::Maketext::Simple 0
+      Test::More 0
+  Perl-OSType-1.010
+    pathname: D/DA/DAGOLDEN/Perl-OSType-1.010.tar.gz
+    provides:
+      Perl::OSType 1.010
+    requirements:
+      Exporter 0
+      ExtUtils::MakeMaker 6.17
+      perl 5.006
+      strict 0
+      warnings 0
   common-sense-3.74
     pathname: M/ML/MLEHMANN/common-sense-3.74.tar.gz
     provides:
       common::sense 3.74
     requirements:
       ExtUtils::MakeMaker 0
+  version-0.9924
+    pathname: J/JP/JPEACOCK/version-0.9924.tar.gz
+    provides:
+      version 0.9924
+      version::regex 0.9924
+      version::vpp 0.9924
+      version::vxs 0.9924
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.006002
 ...
     my $r = cpm_install "-v", "--resolver", "snapshot", "--snapshot", $snapshot, "common::sense";
     is $r->exit, 0;
@@ -121,6 +193,18 @@ subtest '02packages_file' => sub {
         if ($] < 5.016) {
             $cpan->inject('cpan:ExtUtils::MakeMaker@7.24');
             $cpan->inject('cpan:ExtUtils::ParseXS@3.30');
+        }
+        if ($] < 5.010) {
+            $cpan->inject('cpan:ExtUtils::CBuilder@0.280231');
+            $cpan->inject('cpan:IPC::Cmd@1.02');
+            $cpan->inject('cpan:Locale::Maketext::Simple@0.21');
+            $cpan->inject('cpan:Module::CoreList@5.20190420');
+            $cpan->inject('cpan:Module::Load@0.34');
+            $cpan->inject('cpan:Module::Load::Conditional@0.68');
+            $cpan->inject('cpan:Module::Metadata@1.000036');
+            $cpan->inject('cpan:Params::Check@0.38');
+            $cpan->inject('cpan:Perl::OSType@1.010');
+            $cpan->inject('cpan:version@0.9924');
         }
         $cpan->write_index(compress => 1);
 
@@ -149,6 +233,18 @@ subtest '02packages_file_no_prefix' => sub {
     if ($] < 5.016) {
         $cpan->inject('cpan:ExtUtils::MakeMaker@7.24');
         $cpan->inject('cpan:ExtUtils::ParseXS@3.30');
+    }
+    if ($] < 5.010) {
+        $cpan->inject('cpan:ExtUtils::CBuilder@0.280231');
+        $cpan->inject('cpan:IPC::Cmd@1.02');
+        $cpan->inject('cpan:Locale::Maketext::Simple@0.21');
+        $cpan->inject('cpan:Module::CoreList@5.20190420');
+        $cpan->inject('cpan:Module::Load@0.34');
+        $cpan->inject('cpan:Module::Load::Conditional@0.68');
+        $cpan->inject('cpan:Module::Metadata@1.000036');
+        $cpan->inject('cpan:Params::Check@0.38');
+        $cpan->inject('cpan:Perl::OSType@1.010');
+        $cpan->inject('cpan:version@0.9924');
     }
     $cpan->write_index(compress => 1);
     my $r = cpm_install "-v", "--resolver", "02packages,$base", "App::ChangeShebang";

--- a/xt/lib/CLI.pm
+++ b/xt/lib/CLI.pm
@@ -52,7 +52,7 @@ sub cpm_install {
     my ($out, $err, $exit) = capture {
         local %ENV = %ENV;
         delete $ENV{$_} for grep /^PERL_CPM_/, keys %ENV;
-        system $^X, "-I$base/lib", "$base/script/cpm", "install", "-L", $local, "--home", $home, "--exclude-vendor", @argv;
+        system $^X, "-I$base/lib", "$base/script/cpm", "install", "-L", $local, "--home", $home, @argv;
     };
     my $logfile = "$home/build.log";
     Result->new(home => $home, local => $local, out => $out, err => $err, exit => $exit, logfile => $logfile);


### PR DESCRIPTION
Fix #143 

When `cpm install -L Module`,
if some dependencies are in core INC, but not listed in Module::CoreList,
then we should treat them as not being installed.

This also follows the cpanminus behavior.
See https://github.com/miyagawa/cpanminus/blob/7b574ede70cebce3709743ec1727f90d745e8580/Menlo-Legacy/lib/Menlo/CLI/Compat.pm#L1783-L1786