### PR TITLE
call tar with --no-same-owner

### DIFF
--- a/lib/App/cpm/Installer/Unpacker.pm
+++ b/lib/App/cpm/Installer/Unpacker.pm
@@ -104,7 +104,7 @@ sub _untar {
         ($exit, $out, $err) = run3 [$self->{tar}, "${ar}tf", $file];
         last if $exit != 0;
         my $root = $self->_find_tarroot(split /\r?\n/, $out);
-        ($exit, $out, $err) = run3 [$self->{tar}, "${ar}xf", $file];
+        ($exit, $out, $err) = run3 [$self->{tar}, "${ar}xf", $file, "-o"];
         return $root if $exit == 0 and -d $root;
     }
     return if !$wantarray;
@@ -126,7 +126,7 @@ sub _untar_bad {
         ($exit, $out, $err) = run3 [$self->{tar}, @opt, "-tf", $temp->filename];
         last if $exit != 0 || !$out;
         my $root = $self->_find_tarroot(split /\r?\n/, $out);
-        ($exit, $out, $err) = run3 [$self->{tar}, @opt, "-xf", $temp->filename];
+        ($exit, $out, $err) = run3 [$self->{tar}, @opt, "-xf", $temp->filename, "-o"];
         return $root if $exit == 0 and -d $root;
     }
     return if !$wantarray;


### PR DESCRIPTION
When tar is run as root it attempts to preserve user & group ownership by
default. If the uid and gid don't exist this can cause tar to fail. A good
example is Number-Compare 0.03, which have uid 831580115 and gid
755412454. Attempting to untar this as root will fail.

While normally we don't expect to be run as root, this is quite common when
running Docker, which in turn is used by many CI environments, including
CircleCI.