### PR TITLE
do not use --force-local for bsdtar

### DIFF
--- a/lib/App/cpm/Installer/Unpacker.pm
+++ b/lib/App/cpm/Installer/Unpacker.pm
@@ -44,7 +44,6 @@ sub _init_untar {
 
     my $tar = $self->{tar} = File::Which::which('gtar') || File::Which::which("tar");
     if ($tar) {
-        my $name = File::Basename::basename($tar);
         my ($exit, $out, $err) = run3 [$tar, '--version'];
         $self->{tar_kind} = $out =~ /bsdtar/ ? "bsd" : "gnu";
         $self->{tar_bad} = 1 if $out =~ /GNU.*1\.13/i || $^O eq 'MSWin32' || $^O eq 'solaris' || $^O eq 'hpux';


### PR DESCRIPTION
```
===> C:\windows\system32\tar.EXE --version
bsdtar 3.3.2 - libarchive 3.3.2 zlib/1.2.5.f-ipp

===> C:\windows\system32\tar.EXE --force-local -zxf D:\a\perl-github-actions-sample\perl-github-actions-sample\App-tldr-0.10.tar.gz -o
tar.EXE: Option --force-local is not supported
Usage:
  List:    tar.EXE -tf <archive-filename>
  Extract: tar.EXE -xf <archive-filename>
  Create:  tar.EXE -cf <archive-filename> [filenames...]
  Help:    tar.EXE --help
===> $? = 256
```