### PR TITLE
dump direct cause of the failure to build log in the end

### DIFF
--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -76,11 +76,18 @@ sub fail {
                             ."because of installing some dependencies failed");
     }
 
-    my @name = (
-        (map { CPAN::DistnameInfo->new($_)->distvname || $_ } @fail_install),
-        (map { $_->distvname } @not_installed),
-    );
-    { resolve => \@fail_resolve, install => [sort @name] };
+    my @fail_install_name = map { CPAN::DistnameInfo->new($_)->distvname || $_ } @fail_install;
+    my @not_installed_name = map { $_->distvname } @not_installed;
+    if (@fail_resolve || @fail_install_name) {
+        $self->{logger}->log("--");
+        $self->{logger}->log(
+            "Installation failed. "
+            . "The direct cause of the failure comes from the following packages/distributions; "
+            . "you may want to grep this log file by them:"
+        );
+        $self->{logger}->log(" * $_") for @fail_resolve, sort @fail_install_name;
+    }
+    { resolve => \@fail_resolve, install => [sort @fail_install_name, @not_installed_name] };
 }
 
 sub jobs { values %{shift->{jobs}} }

--- a/xt/36_fail.t
+++ b/xt/36_fail.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use Test::More;
+
+use lib "xt/lib";
+use CLI;
+
+with_same_local {
+    cpm_install 'Module::Build';
+    my $r = cpm_install '--test', 'CPAN::Test::Dummy::Perl5::Build::DepeFails';
+    isnt $r->exit, 0;
+    my @log = split /\r?\n/, $r->log;
+    like $log[-2], qr/The direct cause of the failure/;
+    like $log[-1], qr/CPAN-Test-Dummy-Perl5-Build-Fails-\d/;
+};
+
+done_testing;


### PR DESCRIPTION
Fix #184 
```
❯ perl -Ilib script/cpm install --test CPAN::Test::Dummy::Perl5::Build::DepeFails
FAIL install CPAN-Test-Dummy-Perl5-Build-Fails-1.03
FAIL install CPAN-Test-Dummy-Perl5-Build-DepeFails-1.02
FAIL install CPAN-Test-Dummy-Perl5-Build-Fails-1.03
0 distribution installed.
See /Users/skaji/.perl-cpm/build.log for details.

❯ tail /Users/skaji/.perl-cpm/build.log
2020-11-06T00:29:07,45197,CPAN-Test-Dummy-Perl5-Build-Fails-1.03| t/00_load.t (Wstat: 0 Tests: 2 Failed: 1)
2020-11-06T00:29:07,45197,CPAN-Test-Dummy-Perl5-Build-Fails-1.03|   Failed test:  2
2020-11-06T00:29:07,45197,CPAN-Test-Dummy-Perl5-Build-Fails-1.03| Files=1, Tests=2,  0 wallclock secs ( 0.01 usr  0.01 sys +  0.00 cusr  0.01 csys =  0.03 CPU)
2020-11-06T00:29:07,45197,CPAN-Test-Dummy-Perl5-Build-Fails-1.03| Result: FAIL
2020-11-06T00:29:07,45197,CPAN-Test-Dummy-Perl5-Build-Fails-1.03| Failed 1/1 test programs. 1/2 subtests failed.
2020-11-06T00:29:07,45197,CPAN-Test-Dummy-Perl5-Build-Fails-1.03| Failed to install distribution
2020-11-06T00:29:07,45179,CPAN-Test-Dummy-Perl5-Build-DepeFails-1.02| Failed to install distribution, because of installing some dependencies failed
2020-11-06T00:29:07,45179| --
2020-11-06T00:29:07,45179| Installation failed. The direct cause of the failure comes from the following packages/distributions; you may want to grep this log file by them:
2020-11-06T00:29:07,45179|  * CPAN-Test-Dummy-Perl5-Build-Fails-1.03
```