### PR TITLE
show more info in cpm --version

### DIFF
--- a/lib/App/cpm/CLI.pm
+++ b/lib/App/cpm/CLI.pm
@@ -222,6 +222,25 @@ sub cmd_version {
     if ($App::cpm::GIT_DESCRIBE) {
         print "This is a self-contained version, $App::cpm::GIT_DESCRIBE ($App::cpm::GIT_URL)\n";
     }
+
+    print "perl version $^V ($^X)\n\n";
+
+    print "  \%Config:\n";
+    for my $key (qw( archname installsitelib installsitebin installman1dir installman3dir
+                     sitearchexp sitelibexp vendorarch vendorlibexp archlibexp privlibexp )) {
+        print "    $key=$Config{$key}\n" if $Config{$key};
+    }
+
+    print "  \%ENV:\n";
+    for my $key (grep /^PERL/, sort keys %ENV) {
+        print "    $key=$ENV{$key}\n";
+    }
+
+    print "  \@INC:\n";
+    for my $inc (@INC) {
+        print "    $inc\n" unless ref($inc) eq 'CODE';
+    }
+
     return 0;
 }
 

--- a/lib/App/cpm/CLI.pm
+++ b/lib/App/cpm/CLI.pm
@@ -223,7 +223,7 @@ sub cmd_version {
         print "This is a self-contained version, $App::cpm::GIT_DESCRIBE ($App::cpm::GIT_URL)\n";
     }
 
-    print "perl version $^V ($^X)\n\n";
+    printf "perl version v%vd ($^X)\n\n", $^V;
 
     print "  \%Config:\n";
     for my $key (qw( archname installsitelib installsitebin installman1dir installman3dir


### PR DESCRIPTION
resolve #187 

it shows like:

```
$ perl -Mlib=local/lib/perl5 -Ilib -E 'use App::cpm::CLI; App::cpm::CLI->cmd_version'
cpm 0.994 (-e)
perl version v5.32.0 (/usr/local/Cellar/perl/5.32.0/bin/perl)

  %Config:
    archname=darwin-thread-multi-2level
    installsitelib=/usr/local/Cellar/perl/5.32.0/lib/perl5/site_perl/5.32.0
    installsitebin=/usr/local/Cellar/perl/5.32.0/bin
    installman1dir=/usr/local/Cellar/perl/5.32.0/share/man/man1
    installman3dir=/usr/local/Cellar/perl/5.32.0/share/man/man3
    sitearchexp=/usr/local/Cellar/perl/5.32.0/lib/perl5/site_perl/5.32.0/darwin-thread-multi-2level
    sitelibexp=/usr/local/Cellar/perl/5.32.0/lib/perl5/site_perl/5.32.0
    archlibexp=/usr/local/Cellar/perl/5.32.0/lib/perl5/5.32.0/darwin-thread-multi-2level
    privlibexp=/usr/local/Cellar/perl/5.32.0/lib/perl5/5.32.0
  %ENV:
  @INC:
    local/lib/perl5/5.32.0/darwin-thread-multi-2level
    local/lib/perl5/5.32.0
    local/lib/perl5/darwin-thread-multi-2level
    local/lib/perl5
    lib
    /usr/local/Cellar/perl/5.32.0/lib/perl5/site_perl/5.32.0/darwin-thread-multi-2level
    /usr/local/Cellar/perl/5.32.0/lib/perl5/site_perl/5.32.0
    /usr/local/Cellar/perl/5.32.0/lib/perl5/5.32.0/darwin-thread-multi-2level
    /usr/local/Cellar/perl/5.32.0/lib/perl5/5.32.0
    /usr/local/lib/perl5/site_perl/5.32.0
```

This is copied from cpanminus: https://github.com/miyagawa/cpanminus/blob/devel/Menlo-Legacy/lib/Menlo/CLI/Compat.pm#L568-L591