### PR TITLE
introduce cpmfile

### DIFF
--- a/META.json
+++ b/META.json
@@ -65,6 +65,7 @@
             "Module::Metadata" : "0",
             "Parallel::Pipes" : "0.004",
             "Parse::PMFile" : "0.43",
+            "YAML::PP" : "0.026",
             "local::lib" : "2.000018",
             "parent" : "0",
             "perl" : "5.008001",
@@ -152,6 +153,9 @@
       "App::cpm::Worker::Resolver" : {
          "file" : "lib/App/cpm/Worker/Resolver.pm"
       },
+      "App::cpm::file" : {
+         "file" : "lib/App/cpm/file.pm"
+      },
       "App::cpm::version" : {
          "file" : "lib/App/cpm/version.pm"
       }
@@ -182,7 +186,7 @@
       "Shoichi Kaji <skaji@outlook.com>",
       "Will Sheppard <will.sheppard.uk@gmail.com>"
    ],
-   "x_generated_by_perl" : "v5.32.0",
+   "x_generated_by_perl" : "v5.32.1",
    "x_serialization_backend" : "Cpanel::JSON::XS version 4.25",
    "x_spdx_expression" : "Artistic-1.0-Perl OR GPL-1.0-or-later",
    "x_static_install" : 1

--- a/cpanfile
+++ b/cpanfile
@@ -18,6 +18,7 @@ requires 'Module::CPANfile';
 requires 'Module::Metadata';
 requires 'Parallel::Pipes', '0.004';
 requires 'Parse::PMFile', '0.43';
+requires 'YAML::PP', '0.026';
 requires 'local::lib', '2.000018';
 requires 'parent';
 requires 'version', '0.77';

--- a/lib/App/cpm/file.pm
+++ b/lib/App/cpm/file.pm
@@ -1,0 +1,30 @@
+package App::cpm::file;
+use strict;
+use warnings;
+
+use CPAN::Meta::Prereqs;
+use YAML::PP ();
+
+sub new {
+    my ($class, $file) = @_;
+    my ($data) = YAML::PP->new->load_file($file);
+    bless { data => $data }, $class;
+}
+
+sub cpanmeta_prereqs {
+    my $self = shift;
+    my %hash;
+    for my $phase (sort keys %{$self->{data}{prereqs}}) {
+        for my $type (sort keys %{$self->{data}{prereqs}{$phase}}) {
+            my $specs = $self->{data}{prereqs}{$phase}{$type};
+            for my $package (sort keys %$specs) {
+                my $option = $specs->{$package} || +{};
+                my $version = $option->{version} || 0;
+                $hash{$phase}{$type}{$package} = $version;
+            }
+        }
+    }
+    CPAN::Meta::Prereqs->new(\%hash);
+}
+
+1;

--- a/xt/19_cpmfile.t
+++ b/xt/19_cpmfile.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+
+use lib "xt/lib";
+use CLI;
+use Path::Tiny;
+
+subtest basic => sub {
+    my $cpmfile = Path::Tiny->tempfile;
+    $cpmfile->spew(<<'EOF');
+prereqs:
+    runtime:
+        requires:
+            File::pushd: { version: '== 1.014' }
+EOF
+
+    my $r = cpm_install "--cpmfile", $cpmfile;
+    like $r->err, qr/DONE install File-pushd-1.014/;
+};
+
+done_testing;


### PR DESCRIPTION
This PR introduces cpmfile (cpm.yml), which is a new file format describing dependencies.

An example of cpmfile is:

```yaml
prereqs:
  develop:
    requires:
      Archive::Tar:
      Archive::Zip: { version: '1.68' }
      CPAN::Mirror::Tiny: { version: '0.20' }
      Capture::Tiny:
      Path::Tiny:
      Test::More: { version: '0.98' }
  runtime:
    recommends:
      Carton:
      IO::Uncompress::Gunzip:
    requires:
      CPAN::Common::Index:
      CPAN::DistnameInfo:
      CPAN::Meta:
      CPAN::Meta::Requirements: { version: '2.130' }
      CPAN::Meta::YAML:
      Class::Tiny:
      Command::Runner: { version: '0.100' }
      ExtUtils::Install: { version: '2.20' }
```

Currently cpmfile is almost the same as "prereqs" in META.json/yml.
More interesting features will follow, I hope. eg: https://github.com/skaji/cpm/pull/119