### PR TITLE
Added support for PERL_CPM_MIRROR to set default mirror

### DIFF
--- a/lib/App/cpm/CLI.pm
+++ b/lib/App/cpm/CLI.pm
@@ -40,7 +40,7 @@ sub new {
         dependency_file => undef,
         local_lib => "local",
         cpanmetadb => "https://cpanmetadb.plackperl.org/v1.0/",
-        _default_mirror => 'https://cpan.metacpan.org/',
+        _default_mirror => $ENV{PERL_CPM_MIRROR} // 'https://cpan.metacpan.org/',
         retry => 1,
         configure_timeout => 60,
         build_timeout => 3600,

--- a/xt/37_env_override.t
+++ b/xt/37_env_override.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use Test::More;
+use Capture::Tiny 'capture';
+use App::cpm::CLI;
+
+$ENV{PERL_CPM_MIRROR} = 'https://pan.not-metacpan.org';
+my $cli = App::cpm::CLI->new;
+is $cli->{_default_mirror}, 'https://pan.not-metacpan.org', 'default mirror overridden from ENV';
+
+$cli = App::cpm::CLI->new();
+my ($out, $err, $exit) = capture {
+	$cli->run("--version", '--mirror', 'https://other-pan.not-metacpan.org');
+};
+is $cli->{mirror}, 'https://other-pan.not-metacpan.org/', 'mirror option always has precedence over ENV (and is normalized)';
+
+done_testing();


### PR DESCRIPTION
Adding the environment variable `$ENV{PERL_CPM_MIRROR}` so that it is possible to set a mirror without invoking `cpm` directly with `--mirror`.

A specific usecase for this:

You create a base docker image where you have `PERL_CPM_MIRROR` set to a sensible default value (other than metacpan.org). Containers based on this image picks that up automatically, so that a developer just running `cpm install ...` in their `Dockerfile` will get packages pulled from the correct repository. This is especially useful in environments where you have many images that are based on one base image and you would like to avoid duplication of urls. If the url needs to change you can do that once and not have to go through all Dockerfiles and change them like you would have to if everyone was forced to specify `--mirror`.

This change is however not limited to the above usecase. It also makes it convenient to do a quick `export PERL_CPM_MIRROR=...` in your environment and from that point on not have to remember to run `cpm` with `--mirror` all the time.

I've made the change in such a way that `--mirror` always has precedence if specified on the commandline, with a fallback to `$ENV[PERL_CPM_MIRROR` if set, or lastly `https://cpan.metacpan.org` as a last resort.