### PR TITLE
check http status code when fetching tarballs

### DIFF
--- a/lib/App/cpm/Worker/Installer/Menlo.pm
+++ b/lib/App/cpm/Worker/Installer/Menlo.pm
@@ -47,6 +47,20 @@ sub unpack {
     $dir;
 }
 
+sub mirror {
+    my ($self, $uri, $local) = @_;
+    if ($uri =~ /^file:/) {
+        return $self->file_mirror($uri, $local);
+    }
+
+    my $res = $self->{http}->mirror($uri, $local);
+    $self->{logger}->log($res->{status} . ($res->{reason} ? " $res->{reason}" : ""));
+    return 1 if $res->{success};
+    unlink $local;
+    $self->{logger}->log($res->{content}) if $res->{status} == 599;
+    return;
+}
+
 sub log {
     my $self = shift;
     $self->{logger}->log(@_);


### PR DESCRIPTION
Currenly, cpm or cpanminus does not look at HTTP status code when fetching tarballs.
https://github.com/miyagawa/cpanminus/blob/92b34956c52e61c09ae11010f98061730e30fef4/Menlo-Legacy/lib/Menlo/CLI/Compat.pm#L1424-L1425

This PR changes it, and emits HTTP status code to build.log:

```
❯ perl -Ilib script/cpm install --no-prebuilt --home $PWD/home --resolver metadb,https://cpanmetadb.plackperl.org/v1.0/,https://151.101.110.217/  App::cpm
FAIL install App-cpm-0.997006
0 distribution installed.
See /Users/skaji/src/github.com/skaji/cpm/home/build.log for details.
You may want to execute cpm with --show-build-log-on-failure,
so that the build.log is automatically dumped on failure.

❯ cat $PWD/home/build.log
...
2021-09-23T20:55:55,44727,App::cpm| Resolved App::cpm (0) -> https://151.101.110.217/authors/id/S/SK/SKAJI/App-cpm-0.997006.tar.gz from MetaDB
2021-09-23T20:55:55,44727,App-cpm-0.997006| Fetching https://151.101.110.217/authors/id/S/SK/SKAJI/App-cpm-0.997006.tar.gz
2021-09-23T20:55:55,44727,App-cpm-0.997006| 599 Internal Exception
2021-09-23T20:55:55,44727,App-cpm-0.997006| SSL connection failed for 151.101.110.217: hostname verification failed
2021-09-23T20:55:55,44727,App-cpm-0.997006| -> FAIL Download https://151.101.110.217/authors/id/S/SK/SKAJI/App-cpm-0.997006.tar.gz failed. Retrying ...
2021-09-23T20:55:55,44727,App-cpm-0.997006| 599 Internal Exception
2021-09-23T20:55:55,44727,App-cpm-0.997006| SSL connection failed for 151.101.110.217: hostname verification failed
2021-09-23T20:55:55,44727,App-cpm-0.997006| -> FAIL Download https://151.101.110.217/authors/id/S/SK/SKAJI/App-cpm-0.997006.tar.gz failed. Retrying ...
2021-09-23T20:55:55,44727,App-cpm-0.997006| 599 Internal Exception
2021-09-23T20:55:55,44727,App-cpm-0.997006| SSL connection failed for 151.101.110.217: hostname verification failed
2021-09-23T20:55:55,44727,App-cpm-0.997006| -> FAIL Download https://151.101.110.217/authors/id/S/SK/SKAJI/App-cpm-0.997006.tar.gz failed. Retrying ...
2021-09-23T20:55:55,44727,App-cpm-0.997006| -> FAIL Failed to download https://151.101.110.217/authors/id/S/SK/SKAJI/App-cpm-0.997006.tar.gz
2021-09-23T20:55:55,44727,App-cpm-0.997006| Failed to fetch/configure distribution
```