### PR TITLE
Replace git.io shortener links to full address

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install Dependencies
-        run: curl -fsSL --compressed https://git.io/cpm | perl - install -g --with-develop --with-recommends --show-build-log-on-failure
+        run: curl -fsSL --compressed https://raw.githubusercontent.com/skaji/cpm/master/cpm | perl - install -g --with-develop --with-recommends --show-build-log-on-failure
       - name: Run Tests
         run: prove -lr --timer t xt
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There are 2 ways.
 ### 1) self-contained version
 
 ```sh
-$ curl -fsSL https://git.io/cpm > cpm
+$ curl -fsSL https://raw.githubusercontent.com/skaji/cpm/master/cpm > cpm
 $ chmod +x cpm
 $ ./cpm --version
 ```
@@ -19,7 +19,7 @@ $ ./cpm --version
 ### 2) From CPAN
 
 ```sh
-$ curl -fsSL https://git.io/cpm | perl - install -g App::cpm
+$ curl -fsSL https://raw.githubusercontent.com/skaji/cpm/master/cpm | perl - install -g App::cpm
 $ cpm --version
 ```
 

--- a/lib/App/cpm/Tutorial.pm
+++ b/lib/App/cpm/Tutorial.pm
@@ -22,11 +22,11 @@ which is fast!
 
 From CPAN:
 
-  $ curl -fsSL https://git.io/cpm | perl - install -g App::cpm
+  $ curl -fsSL https://raw.githubusercontent.com/skaji/cpm/master/cpm | perl - install -g App::cpm
 
 Or, download a I<self-contained> cpm:
 
-  $ curl -fsSL https://git.io/cpm > cpm
+  $ curl -fsSL https://raw.githubusercontent.com/skaji/cpm/master/cpm > cpm
   $ chmod +x cpm
   $ ./cpm --version
 


### PR DESCRIPTION
On April 29th, git.io is going to stop redirecting.

https://github.blog/changelog/2022-04-25-git-io-deprecation/

To prevent breakage to the test runner and the links in the
documentation, let's replace those links to their original full address.