### PR TITLE
Add --quiet flag

### DIFF
--- a/lib/App/cpm/CLI.pm
+++ b/lib/App/cpm/CLI.pm
@@ -79,6 +79,7 @@ sub parse_options {
         "g|global" => \($self->{global}),
         "mirror=s" => \$mirror,
         "v|verbose" => \($self->{verbose}),
+        "q|quiet" => \($self->{quiet}),
         "w|workers=i" => \($self->{workers}),
         "target-perl=s" => \my $target_perl,
         "test!" => sub { $self->{notest} = $_[1] ? 0 : 1 },
@@ -133,9 +134,13 @@ sub parse_options {
     if ($self->{pureperl_only} or $self->{sudo} or !$self->{notest} or $self->{man_pages} or $] < 5.012) {
         $self->{prebuilt} = 0;
     }
+    if ($self->{verbose} && $self->{quiet}) {
+        die "--quiet option conflicts with --verbose option\n";
+    }
 
     $App::cpm::Logger::COLOR = 1 if $self->{color};
     $App::cpm::Logger::VERBOSE = 1 if $self->{verbose};
+    $App::cpm::Logger::QUIET = 1 if $self->{quiet};
     $App::cpm::Logger::SHOW_PROGRESS = 1 if $self->{show_progress};
 
     if (@ARGV) {
@@ -282,6 +287,7 @@ sub cmd_install {
 
     my $worker = App::cpm::Worker->new(
         verbose   => $self->{verbose},
+        quiet     => $self->{quiet},
         home      => $self->{home},
         logger    => $logger,
         notest    => $self->{notest},

--- a/lib/App/cpm/Logger.pm
+++ b/lib/App/cpm/Logger.pm
@@ -7,6 +7,7 @@ use List::Util 'max';
 
 our $COLOR;
 our $VERBOSE;
+our $QUIET;
 our $SHOW_PROGRESS;
 
 my %color = (
@@ -35,6 +36,7 @@ sub log {
     my $result = $option{result};
     my $is_color = ref $self ? $self->{color} : $COLOR;
     my $verbose = ref $self ? $self->{verbose} : $VERBOSE;
+    my $quiet = ref $self ? $self->{quiet} : $QUIET;
     my $show_progress = ref $self ? $self->{show_progress} : $SHOW_PROGRESS;
 
     if ($is_color and WIN32) {
@@ -55,7 +57,7 @@ sub log {
         # type -> 5 + 9 + 3
         $type = $is_color && $type ? sprintf("%-17s", $type) : sprintf("%-9s", $type || "");
         warn $r . sprintf "%d %s %s %s%s\n", $option{pid} || $$, $result, $type, $message, $optional;
-    } else {
+    } elsif (!$quiet) {
         warn $r . join(" ", $result, $type ? $type : (), $message . $optional) . "\n";
     }
 }

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -163,6 +163,7 @@ sub _show_progress {
     my $self = shift;
     my $all = keys %{$self->{distributions}};
     my $num = $self->installed_distributions;
+    return if $App::cpm::Logger::QUIET;
     print STDERR "--- $num/$all ---";
     STDERR->flush; # this is needed at least with perl <= 5.24
 }

--- a/script/cpm
+++ b/script/cpm
@@ -54,6 +54,8 @@ cpm - a fast CPAN module installer
         directory to install modules into, default: local/
   -g, --global
         install modules into current @INC instead of local/
+  -q, --quiet
+        quiet mode; suppress standard output
   -v, --verbose
         verbose mode; you can see what is going on
       --prebuilt, --no-prebuilt


### PR DESCRIPTION
Hey! This popped into my head as a potential feature. It lets me run cpm like

```
👾  test-project git:(master) ✗ cpm install --quiet
32 distributions installed.
```

I pretty much copied the existing logic for `--verbose`. It's pretty trivial, so no worries if you're not interested.

Thanks for your work! Discovering cpm many years ago greatly changed how I approach managing dependencies. Cheers :)