### PR TITLE
improve resolvers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         perl-version:
-          # - '5.8-buster'
+          - '5.8-buster'
           - '5.10-buster'
           - '5.16-buster'
           - '5.18-buster'

--- a/lib/App/cpm/CLI.pm
+++ b/lib/App/cpm/CLI.pm
@@ -533,54 +533,11 @@ sub generate_resolver {
     my $cascade = App::cpm::Resolver::Cascade->new;
     $cascade->add($initial) if $initial;
     if (@{$self->{resolver}}) {
-        for (@{$self->{resolver}}) {
-            my ($klass, @arg) = split /,/, $_;
-            my $resolver;
-            if ($klass =~ /^metadb$/i) {
-                my ($uri, $mirror);
-                if (@arg > 1) {
-                    ($uri, $mirror) = @arg;
-                } elsif (@arg == 1) {
-                    $mirror = $arg[0];
-                } else {
-                    $mirror = $self->{mirror};
-                }
-                $resolver = App::cpm::Resolver::MetaDB->new(
-                    $uri ? (uri => $uri) : (),
-                    mirror => $self->normalize_mirror($mirror),
-                );
-            } elsif ($klass =~ /^metacpan$/i) {
-                $resolver = App::cpm::Resolver::MetaCPAN->new(dev => $self->{dev});
-            } elsif ($klass =~ /^02packages?$/i) {
-                require App::cpm::Resolver::02Packages;
-                my ($path, $mirror);
-                if (@arg > 1) {
-                    ($path, $mirror) = @arg;
-                } elsif (@arg == 1) {
-                    $mirror = $arg[0];
-                } else {
-                    $mirror = $self->{mirror};
-                }
-                $resolver = App::cpm::Resolver::02Packages->new(
-                    $path ? (path => $path) : (),
-                    cache => "$self->{home}/sources",
-                    mirror => $self->normalize_mirror($mirror),
-                );
-            } elsif ($klass =~ /^snapshot$/i) {
-                require App::cpm::Resolver::Snapshot;
-                $resolver = App::cpm::Resolver::Snapshot->new(
-                    path => $self->{snapshot},
-                    mirror => @arg ? $self->normalize_mirror($arg[0]) : $self->{mirror},
-                );
-            } else {
-                my $full_klass = $klass =~ s/^\+// ? $klass : "App::cpm::Resolver::$klass";
-                (my $file = $full_klass) =~ s{::}{/}g;
-                require "$file.pm"; # may die
-                $resolver = $full_klass->new(@arg);
-            }
+        for my $r (@{$self->{resolver}}) {
+            my ($klass, @argv) = split /,/, $r;
+            my $resolver = $self->_generate_resolver($klass, @argv);
             $cascade->add($resolver);
         }
-        return $cascade;
     }
 
     if ($self->{mirror_only}) {
@@ -620,6 +577,51 @@ sub generate_resolver {
     }
 
     $cascade;
+}
+
+sub _generate_resolver {
+    my ($self, $klass, @argv) = @_;
+    if ($klass =~ /^metadb$/i) {
+        my ($uri, $mirror);
+        if (@argv > 1) {
+            ($uri, $mirror) = @argv;
+        } elsif (@argv == 1) {
+            $mirror = $argv[0];
+        } else {
+            $mirror = $self->{mirror};
+        }
+        return App::cpm::Resolver::MetaDB->new(
+            $uri ? (uri => $uri) : (),
+            mirror => $self->normalize_mirror($mirror),
+        );
+    } elsif ($klass =~ /^metacpan$/i) {
+        return App::cpm::Resolver::MetaCPAN->new(dev => $self->{dev});
+    } elsif ($klass =~ /^02packages?$/i) {
+        require App::cpm::Resolver::02Packages;
+        my ($path, $mirror);
+        if (@argv > 1) {
+            ($path, $mirror) = @argv;
+        } elsif (@argv == 1) {
+            $mirror = $argv[0];
+        } else {
+            $mirror = $self->{mirror};
+        }
+        return App::cpm::Resolver::02Packages->new(
+            $path ? (path => $path) : (),
+            cache => "$self->{home}/sources",
+            mirror => $self->normalize_mirror($mirror),
+        );
+    } elsif ($klass =~ /^snapshot$/i) {
+        require App::cpm::Resolver::Snapshot;
+        return App::cpm::Resolver::Snapshot->new(
+            path => $self->{snapshot},
+            mirror => @argv ? $self->normalize_mirror($argv[0]) : $self->{mirror},
+        );
+    }
+    my $full_klass = $klass =~ s/^\+// ? $klass : "App::cpm::Resolver::$klass";
+    (my $file = $full_klass) =~ s{::}{/}g;
+    require "$file.pm"; # may die
+    return $full_klass->new(@argv);
 }
 
 1;

--- a/lib/App/cpm/CLI.pm
+++ b/lib/App/cpm/CLI.pm
@@ -58,6 +58,7 @@ sub new {
         prebuilt => $] >= 5.012 && $prebuilt,
         pureperl_only => 0,
         static_install => 1,
+        default_resolvers => 1,
         %option
     }, $class;
 }
@@ -87,6 +88,7 @@ sub parse_options {
         "snapshot=s" => \($self->{snapshot}),
         "sudo" => \($self->{sudo}),
         "r|resolver=s@" => \@resolver,
+        "default-resolvers!" => \($self->{default_resolvers}),
         "mirror-only" => \($self->{mirror_only}),
         "dev" => \($self->{dev}),
         "man-pages" => \($self->{man_pages}),
@@ -539,6 +541,7 @@ sub generate_resolver {
             $cascade->add($resolver);
         }
     }
+    return $cascade if !$self->{default_resolvers};
 
     if ($self->{mirror_only}) {
         require App::cpm::Resolver::02Packages;

--- a/lib/App/cpm/Resolver/Cascade.pm
+++ b/lib/App/cpm/Resolver/Cascade.pm
@@ -31,6 +31,7 @@ sub resolve {
             return $result;
         }
     }
+    push @error, "no resolver backends" if !@error;
     return { error => join("\n", @error) };
 }
 

--- a/lib/App/cpm/Resolver/Fixed.pm
+++ b/lib/App/cpm/Resolver/Fixed.pm
@@ -1,0 +1,32 @@
+package App::cpm::Resolver::Fixed;
+use strict;
+use warnings;
+
+use parent 'App::cpm::Resolver::MetaDB';
+
+sub new {
+    my $class = shift;
+    my %package;
+    for my $argv (@_) {
+        my ($package, $fixed_version) = split /\@/, $argv;
+        $package{$package} = $fixed_version;
+    }
+    my $self = $class->SUPER::new;
+    $self->{_packages} = \%package;
+    $self;
+}
+
+sub resolve {
+    my ($self, $argv) = @_;
+    my $fixed_version = $self->{_packages}{$argv->{package}};
+    return { error => "not found" } if !$fixed_version;
+    my $version_range = $argv->{version_range};
+    if ($version_range) {
+        $version_range .= ", == $fixed_version";
+    } else {
+        $version_range = "== $fixed_version";
+    }
+    $self->SUPER::resolve({ %$argv, version_range => $version_range });
+}
+
+1;

--- a/lib/App/cpm/Tutorial.pm
+++ b/lib/App/cpm/Tutorial.pm
@@ -129,21 +129,10 @@ change the cpm resolver by C<--resolver/-r> option:
   $ cpm install --resolver 02packages,http://example.com/darkpan Module
   $ cpm install --resolver 02packages,file::///path/to/darkpan   Module
 
-Sometimes, your darkpan is not whole CPAN mirror, but partial,
-so some modules are missing in it.
-Then append C<--resolver metadb> option to fall back to normal MetaDB resolver:
-
-  $ cpm install \
-     --resolver 02packages,http://example.com/darkpan \
-     --resolver metadb \
-     Module
-
-If you host your own darkmetadb for your own darkpan, you can use it too.
-Then append C<--resolver metadb> option to fall back to normal MetaDB resolver:
+If you host your own metadb for your own darkpan, you can use it too:
 
   $ cpm install \
      --resolver metadb,http://example.com/darkmetadb,http://example.com/darkpan \
-     --resolver metadb \
      Module
 
 =cut

--- a/script/cpm
+++ b/script/cpm
@@ -71,6 +71,10 @@ cpm - a fast CPAN module installer
   -r, --resolver=class,args (EXPERIMENTAL, will be removed or renamed)
         specify resolvers, you can use --resolver multiple times
         available classes: metadb/metacpan/02packages/snapshot
+      --no-default-resolvers
+        even if you specify --resolver, cpm continues using the default resolvers.
+        if you just want to use your resolvers specifed by --resolver,
+        you should specify --no-default-resolvers too
       --reinstall
         reinstall the distribution even if you already have the latest version installed
       --dev (EXPERIMENTAL)

--- a/xt/lib/CLI.pm
+++ b/xt/lib/CLI.pm
@@ -49,6 +49,9 @@ sub cpm_install {
     my @argv = @_;
     my $local = $_LOCAL || tempdir DIR => $TEMPDIR;
     my $home  = $_HOME  || tempdir DIR => $TEMPDIR;
+    if ($] < 5.010) {
+        unshift @argv, "--resolver", 'Fixed,CPAN::Meta::Requirements@2.140';
+    }
     my ($out, $err, $exit) = capture {
         local %ENV = %ENV;
         delete $ENV{$_} for grep /^PERL_CPM_/, keys %ENV;


### PR DESCRIPTION
This PR will improve resolvers for cpm.

## Firstly

Previously, if you specify `--resolver` option, cpm disables the default resolvers and tries to use the specified resolvers only.
In the end, this behavior only served to force the users to specify additional resolvers by themselves.
```
cpm install \
  --resolver 02packages,https://example.com/darkpan \
  --resolver metadb \  # most of the time, need to specify metadb resolver
  Module
```
Now cpm continues using the default resolvers even if you specify `--resolver` option; so that you don't need to specify `--resolver metadb` anymore.

## Secondly

The first change is a breaking change. If you still want cpm not to use the default resolvers, then now you can use `--no-defualt-resolvers` option.

## Thirdly

Now we have a handy "Fixed" resolver. If you want to pin some module's versions when resolving modules, then:

```
# A
cpm install --resolver Fixed,Module1@1.23,Module2@0.98 Foo
```

Please note that this is not the same as

```
# B
cpm install Module1@1.23 Module2@0.98
```

* B installs Module1 with version 1.23 and Module2 with 0.98.
* A installs Foo. If we encounter Module1 or Module2 when resolving the dependencies for Foo, then they are resolved by Module1 with version 1.23 and Module2 with version 0.98. In other words, if Foo does not depend on Module1 or Module2, `--resolver fixed,Module1@1.23,Module2@0.98`　has no effect. 