### PR TITLE
Load requirements from META.json/MYMETA.json

### DIFF
--- a/script/cpm
+++ b/script/cpm
@@ -19,8 +19,11 @@ cpm - a fast CPAN module installer
   # install modules with verbose messages
   > cpm install -v Module
 
-  # from cpanfile (with cpanfile.snapshot if any)
+  # from cpmfile/cpanfile (with cpanfile.snapshot if any)
   > cpm install
+
+  # from metafile (META.json or MYMETA.json)
+  > perl Makefile.PL && cpm install --metafile MYMETA.json
 
   # install module into current @INC instead of local/
   > cpm install -g Module
@@ -40,7 +43,7 @@ cpm - a fast CPAN module installer
   > cpm install --resolver 02packages,http://example.com/darkpan Your::Module
   > cpm install --resolver 02packages,file:///path/to/darkpan    Your::Module
 
-  # specify types/phases in cpanfile by "--with-*" and "--without-*" options
+  # specify types/phases in cpmfile/cpanfile/metafile by "--with-*" and "--without-*" options
   > cpm install --with-recommends --without-test
 
 =head1 OPTIONS
@@ -90,8 +93,12 @@ cpm - a fast CPAN module installer
         specify configure/build/test timeout second, default: 60sec, 3600sec, 1800sec
       --show-progress, --no-show-progress
         show progress, default: on
+      --cpmfile=path
+        specify cpmfile path, default: ./cpm.yml
       --cpanfile=path
         specify cpanfile path, default: ./cpanfile
+      --metafile=path
+        specify META file path, default: N/A
       --snapshot=path
         specify cpanfile.snapshot path, default: ./cpanfile.snapshot
   -V, --version
@@ -99,7 +106,7 @@ cpm - a fast CPAN module installer
   -h, --help
         show this help
       --feature=identifier
-        specify the feature to enable in cpanfile; you can use --feature multiple times
+        specify the feature to enable in cpmfile/cpanfile/metafile; you can use --feature multiple times
       --with-requires,   --without-requires   (default: with)
       --with-recommends, --without-recommends (default: without)
       --with-suggests,   --without-suggests   (default: without)
@@ -108,7 +115,7 @@ cpm - a fast CPAN module installer
       --with-test,       --without-test       (default: with)
       --with-runtime,    --without-runtime    (default: with)
       --with-develop,    --without-develop    (default: without)
-        specify types/phases of dependencies in cpanfile to be installed
+        specify types/phases of dependencies in cpmfile/cpanfile/metafile to be installed
       --with-all
         shortcut for --with-requires, --with-recommends, --with-suggests,
         --with-configure, --with-build, --with-test, --with-runtime and --with-develop

--- a/xt/19_metafile.t
+++ b/xt/19_metafile.t
@@ -1,0 +1,49 @@
+use strict;
+use warnings;
+use Test::More;
+
+use lib "xt/lib";
+use CLI;
+use Path::Tiny;
+
+subtest basic => sub {
+    my $metafile = Path::Tiny->tempfile;
+    $metafile->spew(<<'EOF');
+{
+  "name": "_",
+  "version": "1",
+  "dynamic_config": 0,
+  "meta-spec": {
+    "version": 2
+  },
+  "x_static_install": 1,
+  "prereqs": {
+    "runtime": {
+      "requires": {
+        "File::pushd": "0"
+      }
+    }
+  },
+  "optional_features": {
+    "hoge": {
+      "prereqs": {
+        "runtime": {
+          "requires": {
+            "common::sense": "0"
+          }
+        }
+      }
+    }
+  }
+}
+EOF
+    my $r = cpm_install "--metafile", $metafile;
+    like $r->err, qr/DONE install File-pushd-/;
+    unlike $r->err, qr/common-sense/;
+
+    $r = cpm_install "--feature", "hoge", "--metafile", $metafile;
+    like $r->err, qr/DONE install File-pushd-/;
+    like $r->err, qr/DONE install common-sense-/;
+};
+
+done_testing;


### PR DESCRIPTION
Now cpm can load initial requirements from META.json/MYMETA.json.

```shell
# If you have META.json and you know requirements in META.json is exact, then: 
❯ cpm install --metafile META.json

# If you want to let Makefile.PL generate requirements,
# then first execute Makefile.PL to generate MYMETA.json:
❯ perl Makefile.PL
❯ cpm install --metafile MYMETA.json
```