### PR TITLE
try to load initial requirements from Build.PL/Makefile.PL too

### DIFF
--- a/lib/App/cpm/Tutorial.pm
+++ b/lib/App/cpm/Tutorial.pm
@@ -70,8 +70,23 @@ And cpm can install modules from git repositories directly.
 
 =head2 cpanfile and dist/url/mirror/git syntax
 
-If you omit arguments, and there exists C<cpanfile> in the current directory,
-then cpm loads modules from cpanfile, and install them
+If you omit arguments, and there exists one of
+
+=over 4
+
+=item L<cpm.yml|https://metacpan.org/pod/Module::cpmfile>
+
+=item L<cpanfile|https://metacpan.org/dist/Module-CPANfile/view/lib/cpanfile.pod>
+
+=item L<META.json|https://metacpan.org/pod/CPAN::Meta::Spec> (with dynamic_config false)
+
+=item C<Build.PL>
+
+=item C<Makefile.PL>
+
+=back
+
+in the current directory, then cpm loads modules from the file, and install them
 
   $ cat cpanfile
   requires 'Moose', '2.000';

--- a/script/cpm
+++ b/script/cpm
@@ -16,20 +16,19 @@ cpm - a fast CPAN module installer
   # install modules into local/
   > cpm install Module1 Module2 ...
 
-  # install modules with verbose messages
-  > cpm install -v Module
-
-  # from cpmfile/cpanfile (with cpanfile.snapshot if any)
+  # install modules from one of
+  #  * cpm.yml
+  #  * cpanfile
+  #  * META.json (with dynamic_config false)
+  #  * Build.PL
+  #  * Makefile.PL
   > cpm install
-
-  # from metafile (META.json or MYMETA.json)
-  > perl Makefile.PL && cpm install --metafile MYMETA.json
 
   # install module into current @INC instead of local/
   > cpm install -g Module
 
   # read modules from STDIN by specifying "-" as an argument
-  > echo Module1 Module2 | cpm install -
+  > cat module-list.txt | cpm install -
 
   # prefer TRIAL release
   > cpm install --dev Moose

--- a/xt/19_buildfile.t
+++ b/xt/19_buildfile.t
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+use Test::More;
+
+use lib "xt/lib";
+use CLI;
+use Path::Tiny;
+use File::pushd 'tempd';
+
+subtest build_pl => sub {
+    my $guard = tempd;
+    with_same_local {
+        cpm_install 'Module::Build';
+
+        Path::Tiny->new("Build.PL")->spew(<<'EOF');
+use Module::Build;
+my $builder = Module::Build->new(
+    module_name => 'TEST_MODULE',
+    dist_version => '0.1',
+    dist_author => 'skaji',
+    dist_abstract => 'test',
+    no_index => {},
+    requires => { 'File::pushd' => 0 },
+);
+$builder->create_build_script;
+EOF
+        my $r = cpm_install;
+        like $r->err, qr/Executing Build.PL/;
+        like $r->err, qr/DONE install File-pushd-/;
+    };
+};
+
+subtest makefile_pl => sub {
+    my $guard = tempd;
+    Path::Tiny->new("Makefile.PL")->spew(<<'EOF');
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME => 'TEST_MODULE',
+    PREREQ_PM => { 'File::pushd' => 0 },
+);
+EOF
+    my $r = cpm_install;
+    like $r->err, qr/Executing Makefile.PL/;
+    like $r->err, qr/DONE install File-pushd-/;
+};
+
+done_testing;

--- a/xt/19_metafile.t
+++ b/xt/19_metafile.t
@@ -5,6 +5,7 @@ use Test::More;
 use lib "xt/lib";
 use CLI;
 use Path::Tiny;
+use File::pushd 'tempd';
 
 subtest basic => sub {
     my $metafile = Path::Tiny->tempfile;
@@ -44,6 +45,51 @@ EOF
     $r = cpm_install "--feature", "hoge", "--metafile", $metafile;
     like $r->err, qr/DONE install File-pushd-/;
     like $r->err, qr/DONE install common-sense-/;
+};
+
+subtest dynamic_config => sub {
+    my $guard = tempd;
+    Path::Tiny->new('META.json')->spew(<<'EOF');
+{
+  "name": "_",
+  "version": "1",
+  "dynamic_config": 1,
+  "meta-spec": {
+    "version": 2
+  },
+  "prereqs": {
+    "runtime": {
+      "requires": {
+        "File::pushd": "0"
+      }
+    }
+  }
+}
+EOF
+    my $r = cpm_install;
+    isnt $r->exit, 0;
+    unlike $r->err, qr/DONE install File-pushd-/;
+
+    Path::Tiny->new('META.json')->spew(<<'EOF');
+{
+  "name": "_",
+  "version": "1",
+  "dynamic_config": 0,
+  "meta-spec": {
+    "version": 2
+  },
+  "prereqs": {
+    "runtime": {
+      "requires": {
+        "File::pushd": "0"
+      }
+    }
+  }
+}
+EOF
+    $r = cpm_install;
+    is $r->exit, 0;
+    like $r->err, qr/DONE install File-pushd-/;
 };
 
 done_testing;


### PR DESCRIPTION
Now cpm tries to load initial requirements from Build.PL/Makefile.PL too.

```
❯ cd ~/src/github.com/noxxi/p5-io-socket-ssl

❯ ls
BUGS     MANIFEST       Makefile.PL  README.Win32  example  t
Changes  MANIFEST.SKIP  README       docs          lib      tls_fingerprint

❯ cpm install
Executing Makefile.PL to generate MYMETA.json and to determine requirements...
Loading requirements from MYMETA.json...
DONE install Mozilla-CA-20231213 (using prebuilt)
DONE install Net-SSLeay-1.92 (using prebuilt)
2 distributions installed.
```