### PR TITLE
Disclose `--prebuilt` behaviour

### DIFF
--- a/script/cpm
+++ b/script/cpm
@@ -57,7 +57,8 @@ cpm - a fast CPAN module installer
         verbose mode; you can see what is going on
       --prebuilt, --no-prebuilt
         save builds for CPAN distributions; and later, install the prebuilts if available
-        default: on; you can also set $ENV{PERL_CPM_PREBUILT} false to disable this option
+        default: on; you can also set $ENV{PERL_CPM_PREBUILT} false to disable this option.
+        usage of --test and/or --man-pages disables this option.
       --target-perl=VERSION  (EXPERIMENTAL)
         install modules as if version is your perl is VERSION
       --mirror=URL


### PR DESCRIPTION
Hi,

It [appears that](https://github.com/skaji/cpm/blob/1a9b27ae7b566e3dcb1154c186cce8ef4da2d481/Changes#L200-L211) `--prebuilt` cannot be used with `--test` and/or `--man-pages`. But this is not specified anywhere that I could see.

Also, it is not advertised when it happens: like "Disabling --prebuilt because of..."

This simple patch only documents the behaviour in a visible enough place :)