### PR TITLE
Build META files if not included

### DIFF
--- a/lib/App/cpm/Worker/Installer.pm
+++ b/lib/App/cpm/Worker/Installer.pm
@@ -213,9 +213,22 @@ sub fetch {
 
     chdir $dir or die;
 
-    my $meta = $self->_load_metafile($distfile, 'META.json', 'META.yml');
+    my @accepted_meta_files = ('META.json', 'META.yml', 'MYMETA.json', 'MYMETA.yml');
+
+    if (!grep -f, \@accepted_meta_files && grep -f, [ 'Makefile.PL', 'Build.PL' ]) {
+        my $makefile = (-f 'Makefile.PL' ? 'Makefile' : 'Build');
+        $self->{logger}->log("Configuring distribution via $makefile.PL");
+        my @cmd = ($self->{menlo}->{perl}, "$makefile.PL");
+        push @cmd, 'PUREPERL_ONLY=1' if $self->{pureperl_only};
+        $self->_retry(sub {
+            $self->{menlo}->configure(\@cmd, $self->{menlo_dist}, 1);
+            -f $makefile;
+        });
+    }
+
+    my $meta = $self->_load_metafile($distfile, @accepted_meta_files);
     if (!$meta) {
-        $self->{logger}->log("Distribution does not have META.json nor META.yml");
+        $self->{logger}->log("Distribution lacks both META.json and META.yml files, and neither MYMETA.json nor MYMETA.yml can be generated");
         return;
     }
     my $p = $meta->{provides} || $self->menlo->extract_packages($meta, ".");

--- a/xt/37_remote_tar_without_meta_or_module_name.t
+++ b/xt/37_remote_tar_without_meta_or_module_name.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Test::More;
+use lib "xt/lib";
+use CLI;
+
+subtest remote_tar_without_meta_or_module_name => sub {
+    my $r = cpm_install "-v", "https://cpan.metacpan.org/authors/id/G/GC/GCAMPBELL/Data-Diff-0.01.tar.gz";
+    is $r->exit, 0;
+    note $r->err;
+};
+
+subtest fail => sub {
+    my $r = cpm_install "-v", "https://cpan.metacpan.org/authors/id/G/GC/GCAMPBELL/Data-Diff-0.01.xxx";
+    isnt $r->exit, 0;
+    note $r->err;
+};
+
+done_testing;

--- a/xt/38_git_without_meta_or_module_name.t
+++ b/xt/38_git_without_meta_or_module_name.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More;
+use lib "xt/lib";
+use CLI;
+
+subtest git_without_meta_or_module_name => sub {
+    my $r = cpm_install "-v", 'https://github.com/ap/Async.git@v0.14';
+    is $r->exit, 0;
+    note $r->err;
+};
+
+subtest fail => sub {
+    local $ENV{GIT_TERMINAL_PROMPT} = 0;
+    my $r = cpm_install "-v", 'https://github.com/ap/Async.git@xxxxx';
+    isnt $r->exit, 0;
+    note $r->err;
+};
+
+done_testing;


### PR DESCRIPTION
Resolves #210
Resolves #230

Generally allow installing from source archives, source archive URLs and git repositories and use cpm (with options) as drop-in replacement for cpanm.
