### PR TITLE
fail fast if perl version requirements are not satisfied

### DIFF
--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -214,13 +214,6 @@ sub _calculate_tasks {
                     uri => $dist->uri,
                     distvname => $dist->distvname,
                 );
-            } elsif (@need_resolve and !$dist->deps_registered) {
-                $dist->deps_registered(1);
-                my $msg = sprintf "Found configure dependencies: %s",
-                    join(", ", map { sprintf "%s (%s)", $_->{package}, $_->{version_range} || 0 }  @need_resolve);
-                $self->{logger}->log($msg);
-                my $ok = $self->_register_resolve_task(@need_resolve);
-                $self->{_fail_install}{$dist->distfile}++ unless $ok;
             } elsif (!defined $is_satisfied) {
                 my ($req) = grep { $_->{package} eq "perl" } @$dist_requirements;
                 my $msg = sprintf "%s requires perl %s, but you have only %s",
@@ -228,6 +221,13 @@ sub _calculate_tasks {
                 $self->{logger}->log($msg);
                 App::cpm::Logger->log(result => "FAIL", message => $msg);
                 $self->{_fail_install}{$dist->distfile}++;
+            } elsif (@need_resolve and !$dist->deps_registered) {
+                $dist->deps_registered(1);
+                my $msg = sprintf "Found configure dependencies: %s",
+                    join(", ", map { sprintf "%s (%s)", $_->{package}, $_->{version_range} || 0 }  @need_resolve);
+                $self->{logger}->log($msg);
+                my $ok = $self->_register_resolve_task(@need_resolve);
+                $self->{_fail_install}{$dist->distfile}++ unless $ok;
             }
         }
     }
@@ -252,13 +252,6 @@ sub _calculate_tasks {
                     static_builder => $dist->static_builder,
                     prebuilt => $dist->prebuilt,
                 );
-            } elsif (@need_resolve and !$dist->deps_registered) {
-                $dist->deps_registered(1);
-                my $msg = sprintf "Found dependencies: %s",
-                    join(", ", map { sprintf "%s (%s)", $_->{package}, $_->{version_range} || 0 }  @need_resolve);
-                $self->{logger}->log($msg);
-                my $ok = $self->_register_resolve_task(@need_resolve);
-                $self->{_fail_install}{$dist->distfile}++ unless $ok;
             } elsif (!defined $is_satisfied) {
                 my ($req) = grep { $_->{package} eq "perl" } @$dist_requirements;
                 my $msg = sprintf "%s requires perl %s, but you have only %s",
@@ -266,6 +259,13 @@ sub _calculate_tasks {
                 $self->{logger}->log($msg);
                 App::cpm::Logger->log(result => "FAIL", message => $msg);
                 $self->{_fail_install}{$dist->distfile}++;
+            } elsif (@need_resolve and !$dist->deps_registered) {
+                $dist->deps_registered(1);
+                my $msg = sprintf "Found dependencies: %s",
+                    join(", ", map { sprintf "%s (%s)", $_->{package}, $_->{version_range} || 0 }  @need_resolve);
+                $self->{logger}->log($msg);
+                my $ok = $self->_register_resolve_task(@need_resolve);
+                $self->{_fail_install}{$dist->distfile}++ unless $ok;
             }
         }
     }

--- a/xt/14_perl_req.t
+++ b/xt/14_perl_req.t
@@ -22,7 +22,7 @@ subtest ng => sub {
     plan skip_all => 'XXX: failed to install Win32 module' if WIN32;
     my $r = cpm_install "--target-perl", "5.8.0", "HTTP::Tinyish";
     isnt $r->exit, 0;
-    like $r->err, qr/DONE install HTTP-Tiny-/; # install HTTP::Tiny anyway
+    unlike $r->err, qr/DONE install HTTP-Tiny-/;
     unlike $r->err, qr/DONE install HTTP-Tinyish-/;
     note $r->err;
 };


### PR DESCRIPTION
Let's say you use perl v5.30.

Previously, if module X requires modules M1, M2 and perl v5.40,
cpm will try installing M1, M2 even though the perl requirement is not satisfied.

From this PR, cpm fails fast if perl requirements are not satisfied.