### PR TITLE
When pinning and using MetaDB, install freshest

### DIFF
--- a/lib/App/cpm/Resolver/MetaDB.pm
+++ b/lib/App/cpm/Resolver/MetaDB.pm
@@ -59,6 +59,7 @@ sub resolve {
         }
 
         $found[-1]->{latest} = 1;
+        @found = reverse @found;
 
         my $match;
         for my $try (sort { $b->{version_o} <=> $a->{version_o} } @found) {


### PR DESCRIPTION
Hi @skaji 👋🏼 

`cpm` is great, I love it! 😃 

# Without this change
```
$ cpm install --resolver=metadb Pod::Simple::HTMLLegacy@5.01 --reinstall --no-prebuilt
DONE install Pod-Simple-3.20
1 distribution installed.

$ cpm install --resolver=metacpan Pod::Simple::HTMLLegacy@5.01 --reinstall --no-prebuilt
DONE install Pod-Simple-3.45
1 distribution installed.
```

Because MetaDB history [returns several 5.01 versions](https://cpanmetadb.plackperl.org/v1.0/history/Pod::Simple::HTMLLegacy) for `Pod::Simple::HTMLLegacy`:
```
Pod::Simple::HTMLLegacy            5.01  D/DW/DWHEELER/Pod-Simple-3.20.tar.gz
Pod::Simple::HTMLLegacy            5.01  D/DW/DWHEELER/Pod-Simple-3.21.tar.gz
Pod::Simple::HTMLLegacy            5.01  D/DW/DWHEELER/Pod-Simple-3.22.tar.gz
Pod::Simple::HTMLLegacy            5.01  D/DW/DWHEELER/Pod-Simple-3.23.tar.gz
Pod::Simple::HTMLLegacy            5.01  D/DW/DWHEELER/Pod-Simple-3.24.tar.gz
Pod::Simple::HTMLLegacy            5.01  D/DW/DWHEELER/Pod-Simple-3.25.tar.gz
Pod::Simple::HTMLLegacy            5.01  D/DW/DWHEELER/Pod-Simple-3.26.tar.gz
Pod::Simple::HTMLLegacy            5.01  D/DW/DWHEELER/Pod-Simple-3.27.tar.gz
Pod::Simple::HTMLLegacy            5.01  D/DW/DWHEELER/Pod-Simple-3.28.tar.gz
Pod::Simple::HTMLLegacy            5.01  D/DW/DWHEELER/Pod-Simple-3.29.tar.gz
Pod::Simple::HTMLLegacy            5.01  D/DW/DWHEELER/Pod-Simple-3.30.tar.gz
Pod::Simple::HTMLLegacy            5.01  M/MA/MARCGREEN/Pod-Simple-3.31.tar.gz
Pod::Simple::HTMLLegacy            5.01  M/MA/MARCGREEN/Pod-Simple-3.32.tar.gz
Pod::Simple::HTMLLegacy            5.01  K/KH/KHW/Pod-Simple-3.35.tar.gz
Pod::Simple::HTMLLegacy            5.01  K/KH/KHW/Pod-Simple-3.36.tar.gz
Pod::Simple::HTMLLegacy            5.01  K/KH/KHW/Pod-Simple-3.37.tar.gz
Pod::Simple::HTMLLegacy            5.01  K/KH/KHW/Pod-Simple-3.38.tar.gz
Pod::Simple::HTMLLegacy            5.01  K/KH/KHW/Pod-Simple-3.39.tar.gz
Pod::Simple::HTMLLegacy            5.01  K/KH/KHW/Pod-Simple-3.40.tar.gz
Pod::Simple::HTMLLegacy            5.01  K/KH/KHW/Pod-Simple-3.41.tar.gz
Pod::Simple::HTMLLegacy            5.01  K/KH/KHW/Pod-Simple-3.42.tar.gz
Pod::Simple::HTMLLegacy            5.01  K/KH/KHW/Pod-Simple-3.43.tar.gz
Pod::Simple::HTMLLegacy            5.01  K/KH/KHW/Pod-Simple-3.45.tar.gz
```

Do we really want to install the oldest version?
