### PR TITLE
fix 02package resolver

### DIFF
--- a/lib/App/cpm/Util.pm
+++ b/lib/App/cpm/Util.pm
@@ -6,6 +6,8 @@ use Config;
 use Cwd ();
 use Digest::MD5 ();
 use File::Spec;
+use File::Which ();
+use IPC::Run3 ();
 
 use Exporter 'import';
 
@@ -39,6 +41,21 @@ sub determine_home { # taken from Menlo
     }
 
     File::Spec->catdir($homedir, ".perl-cpm");
+}
+
+my $gzip;
+sub gunzip {
+    my ($from, $to) = @_;
+    if (!$gzip) {
+        $gzip = File::Which::which('gzip');
+        die "need gzip command to decompress $from\n" if !$gzip;
+    }
+    my @cmd = ($gzip, "-dc", $from);
+    IPC::Run3::run3(\@cmd, undef, $to, \my $err);
+    return if $? == 0;
+    chomp $err;
+    $err ||= "exit status $?";
+    die "@cmd: $err\n";
 }
 
 1;


### PR DESCRIPTION
Currently, `cpm install --resolver 02package,index.txt,https://cpan.metacpan.org` always copies `index.txt` to `~/.perl-cpm`.

Actually this is not necessary; this PR simplifies the 02package resolver.
