### PR TITLE
--sudo is deprecated and will be removed in cpm version 1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,16 +49,16 @@ jobs:
         include:
           - perl: /usr/bin/perl
             prove: /usr/bin/prove
-            cpm-option: --sudo
+            sudo: 'sudo -H'
           - perl: /opt/homebrew/bin/perl
             prove: /opt/homebrew/bin/prove
-            cpm-option: ''
+            sudo: ''
     steps:
       - uses: actions/checkout@v5
       - name: perl -V
         run: ${{ matrix.perl }} -V
       - name: Install Dependencies
-        run: curl -fsSL --compressed https://raw.githubusercontent.com/skaji/cpm/main/cpm | ${{ matrix.perl }} - install -g ${{ matrix.cpm-option }} --with-develop --with-recommends --show-build-log-on-failure
+        run: curl -fsSL --compressed https://raw.githubusercontent.com/skaji/cpm/main/cpm | ${{ matrix.sudo }} ${{ matrix.perl }} - install -g --with-develop --with-recommends --show-build-log-on-failure
       - name: Run Tests
         run: ${{ matrix.prove }} -lr --timer t xt
 

--- a/lib/App/cpm/CLI.pm
+++ b/lib/App/cpm/CLI.pm
@@ -134,6 +134,7 @@ sub parse_options {
         die "The number of workers must be 1 under WIN32 environment.\n";
     }
     if ($self->{sudo}) {
+        warn "Warning: --sudo is deprecated and will be removed in cpm version 1.\n";
         !system "sudo", $^X, "-e1" or exit 1;
     }
     if ($self->{pureperl_only} or $self->{sudo} or !$self->{notest} or $self->{man_pages} or $] < 5.012) {


### PR DESCRIPTION
The --sudo option runs the final step of installation—placing files into the filesystem—in a separate process escalated to root.

Because this option requires that last step to be split out unconditionally, it becomes an obstacle when trying to optimize the overall installation pipeline.

Since users can instead run commands like sudo -H cpm install ..., this PR deprecates the --sudo option.