### PR TITLE
introduce App::cpm::Context

### DIFF
--- a/META.json
+++ b/META.json
@@ -82,6 +82,9 @@
       "App::cpm::CircularDependency" : {
          "file" : "lib/App/cpm/CircularDependency.pm"
       },
+      "App::cpm::Context" : {
+         "file" : "lib/App/cpm/Context.pm"
+      },
       "App::cpm::DistNotation" : {
          "file" : "lib/App/cpm/DistNotation.pm"
       },

--- a/lib/App/cpm/Context.pm
+++ b/lib/App/cpm/Context.pm
@@ -1,0 +1,53 @@
+package App::cpm::Context;
+use strict;
+use warnings;
+
+use App::cpm::HTTP;
+use App::cpm::Installer::Unpacker;
+use App::cpm::Logger::File;
+use Command::Runner;
+use Config;
+use File::Which ();
+
+sub new {
+    my ($class, %argv) = @_;
+    my $logger = App::cpm::Logger::File->new($argv{log_file});
+    my ($http, $http_description) = App::cpm::HTTP->create;
+    my $unpacker = App::cpm::Installer::Unpacker->new;
+    my $make = File::Which::which($Config{make});
+    bless {
+        logger => $logger,
+        make => $make,
+        perl => $^X,
+        http => $http,
+        http_description => $http_description,
+        unpacker => $unpacker,
+    }, $class;
+}
+
+sub log {
+    my ($self, @msg) = @_;
+    $self->{logger}->log(@msg);
+}
+
+sub run_command {
+    my ($self, $cmd, $timeout) = @_;
+    my $str = ref $cmd eq 'CODE' ? '' : ref $cmd eq 'ARRAY' ? "@$cmd" : $cmd;
+    $self->log("Executing $str") if $str;
+    my $runner = Command::Runner->new(
+        command => $cmd,
+        keep => 0,
+        redirect => 1,
+        timeout => $timeout,
+        stdout => sub { $self->log(@_) },
+    );
+    my $res = $runner->run;
+    if ($res->{timeout}) {
+        $self->log("Timed out (> ${timeout}s).");
+        return;
+    }
+    my $result = $res->{result};
+    ref $cmd eq 'CODE' ? $result : $result == 0;
+}
+
+1;

--- a/lib/App/cpm/HTTP.pm
+++ b/lib/App/cpm/HTTP.pm
@@ -5,14 +5,49 @@ use warnings;
 use App::cpm;
 use HTTP::Tinyish;
 
+{
+    package App::cpm::HTTP::_HTTPTiny;
+    $INC{"App/cpm/HTTP/_HTTPTiny.pm"} = __FILE__;
+    use parent 'HTTP::Tinyish::Base';
+    use HTTP::Tiny;
+    my %supports = (http => 1);
+    sub configure {
+        my %meta = ("HTTP::Tiny" => $HTTP::Tiny::VERSION);
+        $supports{https} = HTTP::Tiny->can_ssl;
+        \%meta;
+    }
+    sub supports { $supports{$_[1]} }
+    sub new {
+        my ($class, %argv) = @_;
+        bless { _conns => {}, _new_argv => \%argv }, $class;
+    }
+    sub _tiny {
+        my ($self, $url) = @_;
+        my ($key) = $url =~ m{^(https?://[^/]+)};
+        $key ||= "_";
+        $self->{_conns}{$key} ||= HTTP::Tiny->new(%{$self->{_new_argv}});
+    }
+    sub request {
+        my ($self, $method, $url, @argv) = @_;
+        $self->_tiny($url)->request($method, $url, @argv);
+    }
+    sub mirror {
+        my ($self, $url, @argv) = @_;
+        $self->_tiny($url)->mirror($url, @argv);
+    }
+}
+
+
 sub create {
     my ($class, %args) = @_;
     my $wantarray = wantarray;
 
     my @try = $args{prefer} ? @{$args{prefer}} : qw(HTTPTiny LWP Curl Wget);
+    @try = map { "HTTP::Tinyish::$_" } @try;
+    @try = map { $_ eq "HTTP::Tinyish::HTTPTiny" ? "App::cpm::HTTP::_HTTPTiny": $_ } @try;
 
     my ($backend, $tool, $desc);
-    for my $try (map "HTTP::Tinyish::$_", @try) {
+    for my $try (@try) {
         my $meta = HTTP::Tinyish->configure_backend($try) or next;
         $try->supports("https") or next;
         ($tool) = sort keys %$meta;
@@ -29,7 +64,7 @@ sub create {
     );
     my $keep_alive = exists $args{keep_alive} ? $args{keep_alive} : 1;
     if ($keep_alive and $backend =~ /LWP$/) {
-        $http->{ua}->conn_cache({ total_capacity => 1 });
+        $http->{ua}->conn_cache({ total_capacity => 3 });
     }
 
     $wantarray ? ($http, "$tool $desc") : $http;

--- a/lib/App/cpm/Logger/File.pm
+++ b/lib/App/cpm/Logger/File.pm
@@ -54,14 +54,4 @@ sub log {
     }
 }
 
-sub log_with_fh {
-    my ($self, $fh) = @_;
-    my $prefix = $self->prefix;
-    local $self->{fh} = IO::File->new($self->{file}, 'a') if WIN32;
-    while (my $line = <$fh>) {
-        chomp $line;
-        print { $self->{fh} } "@{[POSIX::strftime('%Y-%m-%dT%H:%M:%S', localtime)]},$prefix| $line\n";
-    }
-}
-
 1;

--- a/lib/App/cpm/Resolver/Cascade.pm
+++ b/lib/App/cpm/Resolver/Cascade.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 
 sub new {
-    my $class = shift;
+    my ($class, $ctx) = @_;
     bless { backends => [] }, $class;
 }
 
@@ -14,12 +14,12 @@ sub add {
 }
 
 sub resolve {
-    my ($self, $task) = @_;
+    my ($self, $ctx, $task) = @_;
     # here task = { package => "Plack", version_range => ">= 1.000, < 1.0030" }
 
     my @error;
     for my $backend (@{ $self->{backends} }) {
-        my $result = $backend->resolve($task);
+        my $result = $backend->resolve($ctx, $task);
         next unless $result;
 
         my $klass = ref $backend;

--- a/lib/App/cpm/Resolver/Custom.pm
+++ b/lib/App/cpm/Resolver/Custom.pm
@@ -5,7 +5,7 @@ use warnings;
 use App::cpm::DistNotation;
 
 sub new {
-    my ($class, %argv) = @_;
+    my ($class, $ctx, %argv) = @_;
 
     my $from = $argv{from};
     my $requirements = $argv{requirements};
@@ -67,7 +67,7 @@ sub effective {
 }
 
 sub resolve {
-    my ($self, $task) = @_;
+    my ($self, $ctx, $task) = @_;
     my $found = $self->{resolve}{$task->{package}};
     if (!$found) {
         return { error => "not found in $self->{from}" };

--- a/lib/App/cpm/Resolver/Fixed.pm
+++ b/lib/App/cpm/Resolver/Fixed.pm
@@ -6,6 +6,7 @@ use parent 'App::cpm::Resolver::MetaDB';
 
 sub new {
     my $class = shift;
+    my $ctx = shift;
     my %package;
     for my $argv (@_) {
         my ($package, $fixed_version) = split /\@/, $argv;
@@ -17,7 +18,7 @@ sub new {
 }
 
 sub resolve {
-    my ($self, $argv) = @_;
+    my ($self, $ctx, $argv) = @_;
     my $fixed_version = $self->{_packages}{$argv->{package}};
     return { error => "not found" } if !$fixed_version;
     my $version_range = $argv->{version_range};
@@ -26,7 +27,7 @@ sub resolve {
     } else {
         $version_range = "== $fixed_version";
     }
-    $self->SUPER::resolve({ %$argv, version_range => $version_range });
+    $self->SUPER::resolve($ctx, { %$argv, version_range => $version_range });
 }
 
 1;

--- a/lib/App/cpm/Resolver/MetaCPAN.pm
+++ b/lib/App/cpm/Resolver/MetaCPAN.pm
@@ -3,15 +3,13 @@ use strict;
 use warnings;
 
 use App::cpm::DistNotation;
-use App::cpm::HTTP;
 use JSON::PP ();
 
 sub new {
-    my ($class, %option) = @_;
+    my ($class, $ctx, %option) = @_;
     my $uri = $option{uri} || "https://fastapi.metacpan.org/v1/download_url/";
     $uri =~ s{/*$}{/};
-    my $http = App::cpm::HTTP->create;
-    bless { %option, uri => $uri, http => $http }, $class;
+    bless { %option, uri => $uri }, $class;
 }
 
 sub _encode {
@@ -21,7 +19,7 @@ sub _encode {
 }
 
 sub resolve {
-    my ($self, $task) = @_;
+    my ($self, $ctx, $task) = @_;
     if ($self->{only_dev} and !$task->{dev}) {
         return { error => "skip, because MetaCPAN is configured to resolve dev releases only" };
     }
@@ -34,7 +32,7 @@ sub resolve {
     my $uri = "$self->{uri}$task->{package}" . ($query ? "?$query" : "");
     my $res;
     for (1..2) {
-        $res = $self->{http}->get($uri);
+        $res = $ctx->{http}->get($uri);
         last if $res->{success} or $res->{status} == 404;
     }
     if (!$res->{success}) {

--- a/lib/App/cpm/Resolver/Snapshot.pm
+++ b/lib/App/cpm/Resolver/Snapshot.pm
@@ -7,7 +7,7 @@ use App::cpm::version;
 use Carton::Snapshot;
 
 sub new {
-    my ($class, %option) = @_;
+    my ($class, $ctx, %option) = @_;
     my $snapshot = Carton::Snapshot->new(path => $option{path} || "cpanfile.snapshot");
     $snapshot->load;
     my $mirror = $option{mirror} || "https://cpan.metacpan.org/";
@@ -22,7 +22,7 @@ sub new {
 sub snapshot { shift->{snapshot} }
 
 sub resolve {
-    my ($self, $task) = @_;
+    my ($self, $ctx, $task) = @_;
     my $package = $task->{package};
     my $found = $self->snapshot->find($package);
     if (!$found) {

--- a/lib/App/cpm/Worker/Installer.pm
+++ b/lib/App/cpm/Worker/Installer.pm
@@ -3,18 +3,13 @@ use strict;
 use warnings;
 
 use App::cpm::Builder::Static;
-use App::cpm::HTTP;
-use App::cpm::Installer::Unpacker;
-use App::cpm::Logger::File;
 use App::cpm::Requirement;
 use App::cpm::Util;
 use App::cpm::Worker::Installer::Prebuilt;
 use App::cpm::version;
 use CPAN::DistnameInfo;
 use CPAN::Meta;
-use Command::Runner;
 use Config;
-use ExtUtils::Helpers ();
 use ExtUtils::Install ();
 use ExtUtils::InstallPaths ();
 use File::Basename 'basename';
@@ -36,11 +31,11 @@ my $TRUSTED_MIRROR = sub {
 };
 
 sub work {
-    my ($self, $task) = @_;
+    my ($self, $ctx, $task) = @_;
     my $type = $task->{type} || "(undef)";
-    local $self->{logger}{context} = $task->distvname;
+    local $ctx->{logger}{context} = $task->distvname;
     if ($type eq "fetch") {
-        if (my $result = $self->fetch($task)) {
+        if (my $result = $self->fetch($ctx, $task)) {
             return +{
                 ok => 1,
                 directory => $result->{directory},
@@ -51,23 +46,23 @@ sub work {
                 prebuilt => $result->{prebuilt},
             };
         } else {
-            $self->{logger}->log("Failed to fetch/configure distribution");
+            $ctx->log("Failed to fetch/configure distribution");
         }
     } elsif ($type eq "configure") {
         # $task->{directory}, $task->{distfile}, $task->{meta});
-        if (my $result = $self->configure($task)) {
+        if (my $result = $self->configure($ctx, $task)) {
             return +{
                 ok => 1,
                 requirements => $result->{requirements},
                 static_builder => $result->{static_builder},
             };
         } else {
-            $self->{logger}->log("Failed to configure distribution");
+            $ctx->log("Failed to configure distribution");
         }
     } elsif ($type eq "install") {
-        my $ok = $self->install($task);
+        my $ok = $self->install($ctx, $task);
         my $message = $ok ? "Successfully installed distribution" : "Failed to install distribution";
-        $self->{logger}->log($message);
+        $ctx->log($message);
         return { ok => $ok, directory => $task->{directory} };
     } else {
         die "Unknown type: $type\n";
@@ -76,108 +71,49 @@ sub work {
 }
 
 sub new {
-    my ($class, %option) = @_;
-    $option{logger} ||= App::cpm::Logger::File->new;
-    $option{base}  or die "base option is required\n";
-    $option{cache} or die "cache option is required\n";
-    mkpath $_ for grep !-d, $option{base}, $option{cache};
-    $option{logger}->log("Work directory is $option{base}");
-    my $make = File::Which::which($Config{make});
-    $option{logger}->log("You have make $make") if $make;
-    my ($http, $http_desc) = App::cpm::HTTP->create;
-    $option{logger}->log("You have $http_desc");
-    my $unpacker = App::cpm::Installer::Unpacker->new;
-    my $unpacker_desc = $unpacker->describe;
-    for my $key (sort keys %$unpacker_desc) {
-        $option{logger}->log("You have $key $unpacker_desc->{$key}");
-    }
+    my ($class, $ctx, %option) = @_;
+    $option{work_dir}  or die "work_dir option is required\n";
+    $option{cache_dir} or die "cache_dir option is required\n";
+    mkpath $_ for grep !-d, $option{work_dir}, $option{cache_dir};
     if ($option{local_lib}) {
         $option{local_lib} = App::cpm::Util::maybe_abs($option{local_lib});
     }
 
-    my ($implicit_install_base, $eumm_argv, $mb_argv) = $class->_parse_builder_env;
-    if ($implicit_install_base or @$eumm_argv or @$mb_argv) {
-        $option{logger}->log("Loading configuration from PERL_MM_OPT and PERL_MB_OPT:");
-        $option{logger}->log("  install_base: $implicit_install_base") if $implicit_install_base;
-        $option{logger}->log("  ExtUtils::MakeMaker options: @$eumm_argv") if @$eumm_argv;
-        $option{logger}->log("  Module::Build options: @$mb_argv") if @$mb_argv;
-    }
     my $need_noman_argv = !$option{man_pages} &&
         ($Config{installman1dir} || $Config{installsiteman1dir} || $Config{installman3dir} || $Config{installsiteman3dir});
 
-    my $perl = $^X;
-    $option{logger}->log("--", `$perl -V`, "--");
     $option{prebuilt} = App::cpm::Worker::Installer::Prebuilt->new if $option{prebuilt};
     bless {
         %option,
         need_noman_argv => $need_noman_argv,
-        implicit_install_base => $implicit_install_base,
-        eumm_argv => $eumm_argv,
-        mb_argv => $mb_argv,
-        perl => $perl,
-        make => $make,
-        unpacker => $unpacker,
-        http => $http,
     }, $class;
 }
 
-sub _parse_builder_env {
-    my $class = shift;
-    my ($install_base, @eumm_argv, @mb_argv);
-    if ($ENV{PERL_MM_OPT}) {
-        my @argv = ExtUtils::Helpers::split_like_shell($ENV{PERL_MM_OPT});
-        while (@argv) {
-            my $arg = shift @argv;
-            if ($arg =~ /^INSTALL_BASE=(.+)/) {
-                $install_base = $1;
-            } else {
-                push @eumm_argv, $arg;
-            }
-        }
-        delete $ENV{PERL_MM_OPT};
-    }
-    if ($ENV{PERL_MB_OPT}) {
-        my @argv = ExtUtils::Helpers::split_like_shell($ENV{PERL_MB_OPT});
-        while (@argv) {
-            my $arg = shift @argv;
-            if ($arg eq "--install_base") {
-                $install_base = shift @argv;
-            } elsif ($arg =~ /^--install_base=(.+)/) {
-                $install_base = $1;
-            } else {
-                push @mb_argv, $arg;
-            }
-        }
-        delete $ENV{PERL_MB_OPT};
-    }
-    ($install_base, \@eumm_argv, \@mb_argv);
-}
-
 sub _fetch_git {
-    my ($self, $uri, $ref) = @_;
+    my ($self, $ctx, $uri, $ref) = @_;
     my $basename = File::Basename::basename($uri);
     $basename =~ s/\.git$//;
     $basename =~ s/[^a-zA-Z0-9_.-]/-/g;
     my $dir = File::Temp::tempdir(
         "$basename-XXXXX",
         CLEANUP => 0,
-        DIR => $self->{base},
+        DIR => $self->{work_dir},
     );
-    $self->log("Cloning $uri");
+    $ctx->log("Cloning $uri");
 
     my @depth = $ref ? () : ('--depth=1');
 
     local $ENV{GIT_TERMINAL_PROMPT} = 0 if !exists $ENV{GIT_TERMINAL_PROMPT};
-    $self->run_command([ 'git', 'clone', @depth, $uri, $dir ]);
+    $ctx->run_command([ 'git', 'clone', @depth, $uri, $dir ]);
 
     if (!-e "$dir/.git") {
-        $self->log("Failed cloning git repository $uri");
+        $ctx->log("Failed cloning git repository $uri");
         return;
     }
     my $guard = pushd $dir;
     if ($ref) {
-        if (!$self->run_command([ 'git', 'checkout', $ref ])) {
-            $self->log("Failed to checkout '$ref' in git repository $uri");
+        if (!$ctx->run_command([ 'git', 'checkout', $ref ])) {
+            $ctx->log("Failed to checkout '$ref' in git repository $uri");
             return;
         }
     }
@@ -186,65 +122,65 @@ sub _fetch_git {
 }
 
 sub enable_prebuilt {
-    my ($self, $uri) = @_;
+    my ($self, $ctx, $uri) = @_;
     $self->{prebuilt} && !$self->{prebuilt}->skip($uri) && $TRUSTED_MIRROR->($uri);
 }
 
 sub fetch {
-    my ($self, $task) = @_;
+    my ($self, $ctx, $task) = @_;
     my $guard = pushd;
 
     my $source   = $task->{source};
     my $distfile = $task->{distfile};
     my $uri      = $task->{uri};
 
-    if ($self->enable_prebuilt($uri)) {
-        if (my $result = $self->find_prebuilt($uri)) {
-            $self->{logger}->log("Using prebuilt $result->{directory}");
+    if ($self->enable_prebuilt($ctx, $uri)) {
+        if (my $result = $self->find_prebuilt($ctx, $uri)) {
+            $ctx->log("Using prebuilt $result->{directory}");
             return $result;
         }
     }
 
     my ($dir, $rev, $using_cache);
     if ($source eq "git") {
-        ($dir, $rev) = $self->_fetch_git($uri, $task->{ref});
+        ($dir, $rev) = $self->_fetch_git($ctx, $uri, $task->{ref});
     } elsif ($source eq "local") {
-        $self->{logger}->log("Copying $uri");
+        $ctx->log("Copying $uri");
         $uri =~ s{^file://}{};
         $uri = App::cpm::Util::maybe_abs($uri);
         my $basename = basename $uri;
-        my $g = pushd $self->{base};
+        my $g = pushd $self->{work_dir};
         if (-d $uri) {
             my $dest = File::Temp::tempdir(
                 "$basename-XXXXX",
                 CLEANUP => 0,
-                DIR => $self->{base},
+                DIR => $self->{work_dir},
             );
             File::Copy::Recursive::dircopy($uri, $dest);
             $dir = $dest;
         } elsif (-f $uri) {
             my $dest = $basename;
             File::Copy::copy($uri, $dest);
-            $dir = $self->unpack($basename);
-            $dir = File::Spec->catdir($self->{base}, $dir) if $dir;
+            $dir = $self->unpack($ctx, $basename);
+            $dir = File::Spec->catdir($self->{work_dir}, $dir) if $dir;
         }
     } elsif ($source =~ /^(?:cpan|https?)$/) {
-        my $g = pushd $self->{base};
+        my $g = pushd $self->{work_dir};
 
         FETCH: {
             my $basename = basename $uri;
             if ($uri =~ s{^file://}{}) {
-                $self->{logger}->log("Copying $uri");
+                $ctx->log("Copying $uri");
                 File::Copy::copy($uri, $basename)
                     or last FETCH;
-                $dir = $self->unpack($basename);
+                $dir = $self->unpack($ctx, $basename);
             } else {
                 if ($distfile and $TRUSTED_MIRROR->($uri)) {
-                    my $cache = File::Spec->catfile($self->{cache}, "authors/id/$distfile");
+                    my $cache = File::Spec->catfile($self->{cache_dir}, "authors/id/$distfile");
                     if (-f $cache) {
-                        $self->{logger}->log("Using cache $cache");
+                        $ctx->log("Using cache $cache");
                         File::Copy::copy($cache, $basename);
-                        $dir = $self->unpack($basename);
+                        $dir = $self->unpack($ctx, $basename);
                         if ($dir) {
                             $using_cache++;
                             last FETCH;
@@ -252,27 +188,27 @@ sub fetch {
                         unlink $cache;
                     }
                 }
-                $dir = $self->fetch_distribution($uri, $distfile);
+                $dir = $self->fetch_distribution($ctx, $uri, $distfile);
             }
         }
-        $dir = File::Spec->catdir($self->{base}, $dir) if $dir;
+        $dir = File::Spec->catdir($self->{work_dir}, $dir) if $dir;
     }
     return unless $dir;
 
     chdir $dir or die;
 
-    my $meta = $self->_load_metafile($distfile, 'META.json', 'META.yml');
+    my $meta = $self->_load_metafile($ctx, $distfile, 'META.json', 'META.yml');
     if (!$meta) {
-        $self->{logger}->log("Distribution does not have META.json nor META.yml");
+        $ctx->log("Distribution does not have META.json nor META.yml");
         return;
     }
-    my $provides = $self->extract_packages($meta);
+    my $provides = $self->extract_packages($ctx, $meta);
 
     my $req = { configure => App::cpm::Requirement->new };
-    if ($self->opts_in_static_install($meta)) {
-        $self->{logger}->log("Distribution opts in x_static_install: $meta->{x_static_install}");
+    if ($self->opts_in_static_install($ctx, $meta)) {
+        $ctx->log("Distribution opts in x_static_install: $meta->{x_static_install}");
     } else {
-        $req = { configure => $self->_extract_configure_requirements($meta, $distfile) };
+        $req = { configure => $self->_extract_configure_requirements($ctx, $meta, $distfile) };
     }
 
     return +{
@@ -285,24 +221,24 @@ sub fetch {
 }
 
 sub find_prebuilt {
-    my ($self, $uri) = @_;
+    my ($self, $ctx, $uri) = @_;
     my $info = CPAN::DistnameInfo->new($uri);
     my $dir = File::Spec->catdir($self->{prebuilt_base}, $info->cpanid, $info->distvname);
     return unless -f File::Spec->catfile($dir, ".prebuilt");
 
     my $guard = pushd $dir;
 
-    my $meta   = $self->_load_metafile($uri, 'META.json', 'META.yml');
-    my $mymeta = $self->_load_metafile($uri, 'blib/meta/MYMETA.json');
+    my $meta   = $self->_load_metafile($ctx, $uri, 'META.json', 'META.yml');
+    my $mymeta = $self->_load_metafile($ctx, $uri, 'blib/meta/MYMETA.json');
     my $phase  = $self->{notest} ? [qw(build runtime)] : [qw(build test runtime)];
 
     my %req;
-    if (!$self->opts_in_static_install($meta)) {
+    if (!$self->opts_in_static_install($ctx, $meta)) {
         # XXX Actually we don't need configure requirements for prebuilt.
         # But requires them for consistency for now.
-        %req = ( configure => $self->_extract_configure_requirements($meta, $uri) );
+        %req = ( configure => $self->_extract_configure_requirements($ctx, $meta, $uri) );
     }
-    %req = (%req, %{$self->_extract_requirements($mymeta, $phase)});
+    %req = (%req, %{$self->_extract_requirements($ctx, $mymeta, $phase)});
 
     my $provides = do {
         open my $fh, "<", 'blib/meta/install.json' or die;
@@ -320,7 +256,7 @@ sub find_prebuilt {
 }
 
 sub save_prebuilt {
-    my ($self, $task) = @_;
+    my ($self, $ctx, $task) = @_;
     my $dir = File::Spec->catdir($self->{prebuilt_base}, $task->cpanid, $task->distvname);
 
     if (-d $dir and !File::Path::rmtree($dir)) {
@@ -334,7 +270,7 @@ sub save_prebuilt {
     }
     return unless -d $parent;
 
-    $self->{logger}->log("Saving the build $task->{directory} in $dir");
+    $ctx->log("Saving the build $task->{directory} in $dir");
     if (File::Copy::Recursive::dircopy($task->{directory}, $dir)) {
         open my $fh, ">", File::Spec->catfile($dir, ".prebuilt") or die $!;
     } else {
@@ -343,7 +279,7 @@ sub save_prebuilt {
 }
 
 sub _inject_toolchain_requirements {
-    my ($self, $distfile, $requirement) = @_;
+    my ($self, $ctx, $distfile, $requirement) = @_;
     $distfile ||= "";
 
     if (    -f "Makefile.PL"
@@ -371,11 +307,11 @@ sub _inject_toolchain_requirements {
 }
 
 sub _load_metafile {
-    my ($self, $distfile, @file) = @_;
+    my ($self, $ctx, $distfile, @file) = @_;
     my $meta;
     if (my ($file) = grep -f, @file) {
         $meta = eval { CPAN::Meta->load_file($file) };
-        $self->{logger}->log("Invalid $file: $@") if $@;
+        $ctx->log("Invalid $file: $@") if $@;
     }
 
     if (!$meta and $distfile) {
@@ -388,19 +324,19 @@ sub _load_metafile {
 # XXX Assume current directory is distribution directory
 # because the test "-f Build.PL" or similar is present
 sub _extract_configure_requirements {
-    my ($self, $meta, $distfile) = @_;
-    my $requirement = $self->_extract_requirements($meta, [qw(configure)])->{configure};
+    my ($self, $ctx, $meta, $distfile) = @_;
+    my $requirement = $self->_extract_requirements($ctx, $meta, [qw(configure)])->{configure};
     if ($requirement->empty and -f "Build.PL" and ($distfile || "") !~ m{/Module-Build-[0-9v]}) {
         $requirement->add("Module::Build" => "0.38");
     }
     if (NEED_INJECT_TOOLCHAIN_REQUIREMENTS) {
-        $self->_inject_toolchain_requirements($distfile, $requirement);
+        $self->_inject_toolchain_requirements($ctx, $distfile, $requirement);
     }
     return $requirement;
 }
 
 sub _extract_requirements {
-    my ($self, $meta, $phases) = @_;
+    my ($self, $ctx, $meta, $phases) = @_;
     $phases = [$phases] unless ref $phases;
     my $hash = $meta->effective_prereqs->as_string_hash;
 
@@ -417,50 +353,50 @@ sub _extract_requirements {
 }
 
 sub _retry {
-    my ($self, $sub) = @_;
+    my ($self, $ctx, $sub) = @_;
     return 1 if $sub->();
     return unless $self->{retry};
     Time::HiRes::sleep(0.1);
-    $self->{logger}->log("! Retrying (you can turn off this behavior by --no-retry)");
+    $ctx->log("! Retrying (you can turn off this behavior by --no-retry)");
     return $sub->();
 }
 
 sub configure {
-    my ($self, $task) = @_;
+    my ($self, $ctx, $task) = @_;
     my ($dir, $distfile, $meta, $source) = @{$task}{qw(directory distfile meta source)};
     my $guard = pushd $dir;
 
     my $install_base = $self->{local_lib} || $self->{implicit_install_base};
-    $self->{logger}->log("Configuring distribution");
+    $ctx->log("Configuring distribution");
     my ($static_builder, $configure_ok);
     {
-        if ($self->opts_in_static_install($meta)) {
-            $static_builder = $self->static_install_configure($meta);
+        if ($self->opts_in_static_install($ctx, $meta)) {
+            $static_builder = $self->static_install_configure($ctx, $meta);
             ++$configure_ok and last;
         }
         if (-f 'Build.PL') {
-            my @cmd = ($self->{perl}, 'Build.PL');
+            my @cmd = ($ctx->{perl}, 'Build.PL');
             push @cmd, "--install_base", $install_base if $install_base;
             push @cmd, qw(--config installman1dir= --config installsiteman1dir= --config installman3dir= --config installsiteman3dir=) if $self->{need_noman_argv};
             push @cmd, '--pureperl-only' if $self->{pureperl_only};
             push @cmd, @{$self->{mb_argv}} if @{$self->{mb_argv}};
-            $self->_retry(sub {
-                $self->_configure(\@cmd, $meta);
+            $self->_retry($ctx, sub {
+                $self->_configure($ctx, \@cmd, $meta);
                 -f 'Build';
             }) and ++$configure_ok and last;
         }
         if (-f 'Makefile.PL') {
-            if (!$self->{make}) {
-                $self->{logger}->log("There is Makefile.PL, but you don't have 'make' command; you should install 'make' command first");
+            if (!$ctx->{make}) {
+                $ctx->log("There is Makefile.PL, but you don't have 'make' command; you should install 'make' command first");
                 last;
             }
-            my @cmd = ($self->{perl}, 'Makefile.PL');
+            my @cmd = ($ctx->{perl}, 'Makefile.PL');
             push @cmd, "INSTALL_BASE=$install_base" if $install_base;
             push @cmd, qw(INSTALLMAN1DIR=none INSTALLMAN3DIR=none) if $self->{need_noman_argv};
             push @cmd, 'PUREPERL_ONLY=1' if $self->{pureperl_only};
             push @cmd, @{$self->{eumm_argv}} if @{$self->{eumm_argv}};
-            $self->_retry(sub {
-                $self->_configure(\@cmd, $meta);
+            $self->_retry($ctx, sub {
+                $self->_configure($ctx, \@cmd, $meta);
                 -f 'Makefile';
             }) and ++$configure_ok and last;
         }
@@ -468,8 +404,8 @@ sub configure {
     return unless $configure_ok;
 
     my $phase = $self->{notest} ? [qw(build runtime)] : [qw(build test runtime)];
-    my $mymeta = $self->_load_metafile($distfile, 'MYMETA.json', 'MYMETA.yml');
-    my $req = $self->_extract_requirements($mymeta, $phase);
+    my $mymeta = $self->_load_metafile($ctx, $distfile, 'MYMETA.json', 'MYMETA.yml');
+    my $req = $self->_extract_requirements($ctx, $mymeta, $phase);
     return +{
         requirements => $req,
         static_builder => $static_builder,
@@ -477,32 +413,32 @@ sub configure {
 }
 
 sub _local_lib_env_path {
-    my $self = shift;
+    my ($self, $ctx) = @_;
     join $Config{path_sep}, File::Spec->catdir($self->{local_lib}, "bin"), ( $ENV{PATH} ? $ENV{PATH} : () );
 }
 
 sub _local_lib_env_perl5lib {
-    my $self = shift;
+    my ($self, $ctx) = @_;
     join $Config{path_sep}, File::Spec->catdir($self->{local_lib}, "lib", "perl5"), ( $ENV{PERL5LIB} ? $ENV{PERL5LIB} : ());
 }
 
 sub _configure {
-    my ($self, $cmd, $meta) = @_;
+    my ($self, $ctx, $cmd, $meta) = @_;
     local %ENV = %ENV;
     $ENV{PERL5_CPAN_IS_RUNNING} = $$;
     $ENV{PERL5_CPANPLUS_IS_RUNNING} = $$;
     $ENV{PERL5_CPANM_IS_RUNNING} = $$;
     $ENV{PERL_MM_USE_DEFAULT} = 1;
-    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($meta);
+    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($ctx, $meta);
     if ($self->{local_lib}) {
-        $ENV{PATH} = $self->_local_lib_env_path;
-        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib;
+        $ENV{PATH} = $self->_local_lib_env_path($ctx);
+        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib($ctx);
     }
-    $self->run_timeout($cmd, $self->{configure_timeout});
+    $ctx->run_command($cmd, $self->{configure_timeout});
 }
 
 sub static_install_configure {
-    my ($self, $meta) = @_;
+    my ($self, $ctx, $meta) = @_;
 
     my $builder = App::cpm::Builder::Static->new(meta => $meta);
     my @argv;
@@ -520,8 +456,8 @@ sub static_install_configure {
     }
     local %ENV = %ENV;
     if ($self->{local_lib}) {
-        $ENV{PATH} = $self->_local_lib_env_path;
-        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib;
+        $ENV{PATH} = $self->_local_lib_env_path($ctx);
+        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib($ctx);
     }
     $builder->configure(@argv);
     return $builder;
@@ -529,103 +465,103 @@ sub static_install_configure {
 
 
 sub _build {
-    my ($self, $cmd, $meta) = @_;
+    my ($self, $ctx, $cmd, $meta) = @_;
     local %ENV = %ENV;
     $ENV{PERL_MM_USE_DEFAULT} = 1;
-    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($meta);
+    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($ctx, $meta);
     if ($self->{local_lib}) {
-        $ENV{PATH} = $self->_local_lib_env_path;
-        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib;
+        $ENV{PATH} = $self->_local_lib_env_path($ctx);
+        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib($ctx);
     }
-    $self->run_timeout($cmd, $self->{build_timeout});
+    $ctx->run_command($cmd, $self->{build_timeout});
 }
 
 sub _test {
-    my ($self, $cmd, $meta) = @_;
+    my ($self, $ctx, $cmd, $meta) = @_;
     local %ENV = %ENV;
     $ENV{PERL_MM_USE_DEFAULT} = 1;
-    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($meta);
+    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($ctx, $meta);
     $ENV{NONINTERACTIVE_TESTING} = 1;
     if ($self->{local_lib}) {
-        $ENV{PATH} = $self->_local_lib_env_path;
-        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib;
+        $ENV{PATH} = $self->_local_lib_env_path($ctx);
+        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib($ctx);
     }
-    $self->run_timeout($cmd, $self->{test_timeout});
+    $ctx->run_command($cmd, $self->{test_timeout});
 }
 
 sub _install {
-    my ($self, $cmd, $meta) = @_;
+    my ($self, $ctx, $cmd, $meta) = @_;
     local %ENV = %ENV;
-    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($meta);
+    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($ctx, $meta);
     if ($self->{local_lib}) {
-        $ENV{PATH} = $self->_local_lib_env_path;
-        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib;
+        $ENV{PATH} = $self->_local_lib_env_path($ctx);
+        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib($ctx);
     }
     if (ref $cmd eq 'ARRAY' && $self->{sudo}) {
         unshift @$cmd, 'sudo';
     }
-    $self->run_timeout($cmd, 0);
+    $ctx->run_command($cmd, 0);
 }
 
 sub _use_unsafe_inc {
-    my ($self, $meta) = @_;
+    my ($self, $ctx, $meta) = @_;
     if (exists $ENV{PERL_USE_UNSAFE_INC}) {
         return $ENV{PERL_USE_UNSAFE_INC};
     }
     if (exists $meta->{x_use_unsafe_inc}) {
-        $self->log("Distribution opts in x_use_unsafe_inc: $meta->{x_use_unsafe_inc}"); # XXX
+        $ctx->log("Distribution opts in x_use_unsafe_inc: $meta->{x_use_unsafe_inc}"); # XXX
         return $meta->{x_use_unsafe_inc};
     }
     1;
 }
 
 sub opts_in_static_install {
-    my ($self, $meta) = @_;
+    my ($self, $ctx, $meta) = @_;
     return if !$self->{static_install};
     return if $self->{sudo} or $self->{uninstall_shadows};
     return $meta->{x_static_install} && $meta->{x_static_install} == 1;
 }
 
 sub install {
-    my ($self, $task) = @_;
-    return $self->install_prebuilt($task) if $task->{prebuilt};
+    my ($self, $ctx, $task) = @_;
+    return $self->install_prebuilt($ctx, $task) if $task->{prebuilt};
 
     my ($dir, $static_builder, $distvname, $meta, $provides, $distfile)
         = @{$task}{qw(directory static_builder distvname meta provides distfile)};
     my $guard = pushd $dir;
 
-    $self->{logger}->log("Building " . ($self->{notest} ? "" : "and testing ") . "distribution");
+    $ctx->log("Building " . ($self->{notest} ? "" : "and testing ") . "distribution");
     my $installed;
     if ($static_builder) {
-        $self->_build(sub { $static_builder->build }, $meta)
-        && ($self->{notest} || $self->_test(sub { $static_builder->build("test") }, $meta))
-        && $self->_install(sub { $static_builder->build("install") }, $meta)
+        $self->_build($ctx, sub { $static_builder->build }, $meta)
+        && ($self->{notest} || $self->_test($ctx, sub { $static_builder->build("test") }, $meta))
+        && $self->_install($ctx, sub { $static_builder->build("install") }, $meta)
         && $installed++;
     } elsif (-f 'Build') {
-        $self->_retry(sub { $self->_build([ $self->{perl}, "./Build" ], $meta)  })
-        && ($self->{notest} || $self->_retry(sub { $self->_test([ $self->{perl}, "./Build", "test" ], $meta) }))
-        && $self->_retry(sub { $self->_install([ $self->{perl}, "./Build", "install" ], $meta)  })
+        $self->_retry($ctx, sub { $self->_build($ctx, [ $ctx->{perl}, "./Build" ], $meta)  })
+        && ($self->{notest} || $self->_retry($ctx, sub { $self->_test($ctx, [ $ctx->{perl}, "./Build", "test" ], $meta) }))
+        && $self->_retry($ctx, sub { $self->_install($ctx, [ $ctx->{perl}, "./Build", "install" ], $meta)  })
         && $installed++;
     } else {
-        $self->_retry(sub { $self->_build([ $self->{make} ], $meta)  })
-        && ($self->{notest} || $self->_retry(sub { $self->_test([ $self->{make}, "test" ], $meta) }))
-        && $self->_retry(sub { $self->_install([ $self->{make}, "install" ], $meta) })
+        $self->_retry($ctx, sub { $self->_build($ctx, [ $ctx->{make} ], $meta)  })
+        && ($self->{notest} || $self->_retry($ctx, sub { $self->_test($ctx, [ $ctx->{make}, "test" ], $meta) }))
+        && $self->_retry($ctx, sub { $self->_install($ctx, [ $ctx->{make}, "install" ], $meta) })
         && $installed++;
     }
 
     if ($installed && $distfile) {
-        $self->save_meta($meta, $distfile, $provides);
-        $self->save_prebuilt($task) if $self->enable_prebuilt($task->{uri});
+        $self->save_meta($ctx, $meta, $distfile, $provides);
+        $self->save_prebuilt($ctx, $task) if $self->enable_prebuilt($ctx, $task->{uri});
     }
     return $installed;
 }
 
 sub install_prebuilt {
-    my ($self, $task) = @_;
+    my ($self, $ctx, $task) = @_;
 
     my $install_base = $self->{local_lib} || $self->{implicit_install_base};
 
-    $self->{logger}->log("Copying prebuilt $task->{directory}/blib");
+    $ctx->log("Copying prebuilt $task->{directory}/blib");
     my $guard = pushd $task->{directory};
     my $paths = ExtUtils::InstallPaths->new(
         dist_name => $task->distname, # this enables the installation of packlist
@@ -650,53 +586,21 @@ sub install_prebuilt {
             'blib/meta' => $meta_target_dir,
         });
     }
-    $self->{logger}->log($stdout);
+    $ctx->log($stdout);
     return 1;
 }
 
-sub log {
-    my $self = shift;
-    $self->{logger}->log(@_);
-}
-
-sub run_command {
-    my ($self, $cmd) = @_;
-    $self->run_timeout($cmd, 0);
-}
-
-sub run_timeout {
-    my ($self, $cmd, $timeout) = @_;
-
-    my $str = ref $cmd eq 'CODE' ? '' : ref $cmd eq 'ARRAY' ? "@$cmd" : $cmd;
-    $self->log("Executing $str") if $str;
-
-    my $runner = Command::Runner->new(
-        command => $cmd,
-        keep => 0,
-        redirect => 1,
-        timeout => $timeout,
-        stdout => sub { $self->log(@_) },
-    );
-    my $res = $runner->run;
-    if ($res->{timeout}) {
-        $self->log("Timed out (> ${timeout}s).");
-        return;
-    }
-    my $result = $res->{result};
-    ref $cmd eq 'CODE' ? $result : $result == 0;
-}
-
 sub unpack {
-    my ($self, $file) = @_;
-    $self->log("Unpacking $file");
-    my ($dir, $err) = $self->{unpacker}->unpack($file);
-    $self->log($err) if !$dir && $err;
+    my ($self, $ctx, $file) = @_;
+    $ctx->log("Unpacking $file");
+    my ($dir, $err) = $ctx->{unpacker}->unpack($file);
+    $ctx->log($err) if !$dir && $err;
     $dir;
 }
 
 # XXX assume current dir is distribution dir
 sub extract_packages {
-    my ($self, $meta) = @_;
+    my ($self, $ctx, $meta) = @_;
 
     if (my $provides = $meta->{provides}) {
         my @out;
@@ -730,31 +634,31 @@ sub extract_packages {
 }
 
 sub mirror {
-    my ($self, $uri, $local) = @_;
-    my $res = $self->{http}->mirror($uri, $local);
-    $self->log($res->{status} . ($res->{reason} ? " $res->{reason}" : ""));
+    my ($self, $ctx, $uri, $local) = @_;
+    my $res = $ctx->{http}->mirror($uri, $local);
+    $ctx->log($res->{status} . ($res->{reason} ? " $res->{reason}" : ""));
     return 1 if $res->{success};
     unlink $local;
-    $self->log($res->{content}) if $res->{status} == 599;
+    $ctx->log($res->{content}) if $res->{status} == 599;
     return;
 }
 
 sub fetch_distribution {
-    my ($self, $uri, $distfile) = @_;
+    my ($self, $ctx, $uri, $distfile) = @_;
 
-    my $local = File::Spec->catfile($self->{base}, File::Basename::basename($uri));
-    $self->log("Fetching $uri");
-    if (!$self->mirror($uri, $local)) {
-        $self->log("Failed to download $uri");
+    my $local = File::Spec->catfile($self->{work_dir}, File::Basename::basename($uri));
+    $ctx->log("Fetching $uri");
+    if (!$self->mirror($ctx, $uri, $local)) {
+        $ctx->log("Failed to download $uri");
         return;
     }
-    my $dir = $self->unpack($local);
+    my $dir = $self->unpack($ctx, $local);
     if (!$dir) {
         return;
     }
 
     if ($distfile and $TRUSTED_MIRROR->($uri)) {
-        my $cache = File::Spec->catfile($self->{cache}, "authors/id/$distfile");
+        my $cache = File::Spec->catfile($self->{cache_dir}, "authors/id/$distfile");
         File::Path::mkpath([ File::Basename::dirname($cache) ], 0, 0777);
         File::Copy::copy($local, $cache) or warn $!;
     }
@@ -762,7 +666,7 @@ sub fetch_distribution {
 }
 
 sub save_meta {
-    my ($self, $meta, $distfile, $provides) = @_;
+    my ($self, $ctx, $meta, $distfile, $provides) = @_;
 
     my $install_base = $self->{local_lib} || $self->{implicit_install_base};
     my $install_base_meta = $install_base ? File::Spec->catdir($install_base, "lib", "perl5") : $Config{sitelibexp};
@@ -796,12 +700,12 @@ sub save_meta {
     my $meta_target_dir = File::Spec->catdir($install_base_meta, $Config{archname}, ".meta", $distvname);
     my @cmd = (
         ($self->{sudo} ? 'sudo' : ()),
-        $self->{perl},
+        $ctx->{perl},
         '-MExtUtils::Install=install',
         '-e',
         qq[install({ 'blib/meta' => '$meta_target_dir' })],
     );
-    $self->run_command(\@cmd);
+    $ctx->run_command(\@cmd);
 }
 
 1;

--- a/lib/App/cpm/Worker/Resolver.pm
+++ b/lib/App/cpm/Worker/Resolver.pm
@@ -2,28 +2,25 @@ package App::cpm::Worker::Resolver;
 use strict;
 use warnings;
 
-use App::cpm::Logger::File;
-
 sub new {
-    my ($class, %option) = @_;
-    my $logger = $option{logger} || App::cpm::Logger::File->new;
-    bless { impl => $option{impl}, logger => $logger }, $class;
+    my ($class, $ctx, %option) = @_;
+    bless { impl => $option{impl} }, $class;
 }
 
 sub work {
-    my ($self, $task) = @_;
+    my ($self, $ctx, $task) = @_;
 
-    local $self->{logger}->{context} = $task->{package};
-    my $result = $self->{impl}->resolve($task);
+    local $ctx->{logger}{context} = $task->{package};
+    my $result = $self->{impl}->resolve($ctx, $task);
     if ($result and !$result->{error}) {
         $result->{ok} = 1;
         my $msg = sprintf "Resolved %s (%s) -> %s", $task->{package}, $task->{version_range} || 0,
             $result->{uri} . ($result->{from} ? " from $result->{from}" : "");
-        $self->{logger}->log($msg);
+        $ctx->log($msg);
         return $result;
     } else {
-        $self->{logger}->log($result->{error}) if $result and $result->{error};
-        $self->{logger}->log(sprintf "Failed to resolve %s", $task->{package});
+        $ctx->log($result->{error}) if $result and $result->{error};
+        $ctx->log(sprintf "Failed to resolve %s", $task->{package});
         return { ok => 0 };
     }
 }

--- a/xt/03_resolver.t
+++ b/xt/03_resolver.t
@@ -2,15 +2,17 @@ use strict;
 use warnings;
 use utf8;
 use Test::More;
-use App::cpm::Worker::Resolver;
+use App::cpm::Context;
 use App::cpm::Resolver::Cascade;
 use App::cpm::Resolver::MetaDB;
+use App::cpm::Worker::Resolver;
 
-my $cascade = App::cpm::Resolver::Cascade->new;
-$cascade->add(App::cpm::Resolver::MetaDB->new(uri => "https://cpanmetadb.plackperl.org/v1.0/"));
-my $r = App::cpm::Worker::Resolver->new(impl => $cascade);
+my $ctx = App::cpm::Context->new;
+my $cascade = App::cpm::Resolver::Cascade->new($ctx);
+$cascade->add(App::cpm::Resolver::MetaDB->new($ctx, uri => "https://cpanmetadb.plackperl.org/v1.0/"));
+my $r = App::cpm::Worker::Resolver->new($ctx, impl => $cascade);
 
-my $res = $r->work(+{ package => "Plack", version => 1 });
+my $res = $r->work($ctx, +{ package => "Plack", version => 1 });
 
 like $res->{distfile}, qr/Plack/;
 ok exists $res->{version};

--- a/xt/35_custom_resolver.t
+++ b/xt/35_custom_resolver.t
@@ -16,10 +16,11 @@ path($tempdir, qw(lib App cpm Resolver))->mkpath;
 path($tempdir, qw(lib App cpm Resolver Hoge.pm))->spew_raw(<<'EOF');
 package App::cpm::Resolver::Hoge;
 sub new {
-    bless {}, shift;
+    my ($class, $ctx) = @_;
+    bless {}, $class;
 }
 sub resolve {
-    my ($self, $task) = @_;
+    my ($self, $ctx, $task) = @_;
     if ($task->{package} ne 'App::ChangeShebang') {
         die;
     }
@@ -34,12 +35,12 @@ path($tempdir, qw(lib Foo))->mkpath;
 path($tempdir, qw(lib Foo Bar.pm))->spew_raw(<<'EOF');
 package Foo::Bar;
 sub new {
-    my ($class, @argv) = @_;
+    my ($class, $ctx, @argv) = @_;
     die if !(@argv == 2 && $argv[0] eq "arg1" && $argv[1] eq "arg2");
     bless {}, shift;
 }
 sub resolve {
-    my ($self, $task) = @_;
+    my ($self, $ctx, $task) = @_;
     if ($task->{package} ne 'App::ChangeShebang') {
         die;
     }


### PR DESCRIPTION
Several cross-cutting features—most notably HTTP handling and logging—are needed across multiple modules.
At the moment, each module implements these features on its own, which is honestly not ideal.

This PR introduces a Context module to centralize these shared concerns.
Each module’s methods are updated to take a Context object as their first argument, allowing them to access HTTP, logging, and related functionality in a consistent and unified way.