### PR TITLE
Refactor installer build logic into builders

### DIFF
--- a/lib/App/cpm/Builder.pm
+++ b/lib/App/cpm/Builder.pm
@@ -1,0 +1,81 @@
+package App::cpm::Builder;
+use v5.24;
+use warnings;
+use experimental qw(signatures);
+
+use Config;
+use File::Spec;
+
+sub new ($class, %args) {
+    bless \%args, $class;
+}
+
+sub meta ($self) {
+    $self->{meta};
+}
+
+sub local_lib ($self) {
+    $self->{local_lib};
+}
+
+sub _local_lib_env_path ($self) {
+    join $Config{path_sep}, File::Spec->catdir($self->local_lib, "bin"), ( $ENV{PATH} ? $ENV{PATH} : () );
+}
+
+sub _local_lib_env_perl5lib ($self) {
+    join $Config{path_sep}, File::Spec->catdir($self->local_lib, "lib", "perl5"), ( $ENV{PERL5LIB} ? $ENV{PERL5LIB} : ());
+}
+
+sub _set_local_lib_env ($self) {
+    return if !$self->local_lib;
+    $ENV{PATH} = $self->_local_lib_env_path;
+    $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib;
+}
+
+sub _use_unsafe_inc ($self, $ctx) {
+    if (exists $ENV{PERL_USE_UNSAFE_INC}) {
+        return $ENV{PERL_USE_UNSAFE_INC};
+    }
+    if (exists $self->meta->{x_use_unsafe_inc}) {
+        $ctx->log("Distribution opts in x_use_unsafe_inc: $self->{meta}{x_use_unsafe_inc}"); # XXX
+        return $self->meta->{x_use_unsafe_inc};
+    }
+    1;
+}
+
+sub run_configure ($self, $ctx, $cmd) {
+    local %ENV = %ENV;
+    $ENV{PERL5_CPAN_IS_RUNNING} = $$;
+    $ENV{PERL5_CPANPLUS_IS_RUNNING} = $$;
+    $ENV{PERL5_CPANM_IS_RUNNING} = $$;
+    $ENV{PERL_MM_USE_DEFAULT} = 1;
+    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($ctx);
+    $self->_set_local_lib_env;
+    $ctx->run_command($cmd, $self->{configure_timeout});
+}
+
+sub run_build ($self, $ctx, $cmd) {
+    local %ENV = %ENV;
+    $ENV{PERL_MM_USE_DEFAULT} = 1;
+    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($ctx);
+    $self->_set_local_lib_env;
+    $ctx->run_command($cmd, $self->{build_timeout});
+}
+
+sub run_test ($self, $ctx, $cmd) {
+    local %ENV = %ENV;
+    $ENV{PERL_MM_USE_DEFAULT} = 1;
+    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($ctx);
+    $ENV{NONINTERACTIVE_TESTING} = 1;
+    $self->_set_local_lib_env;
+    $ctx->run_command($cmd, $self->{test_timeout});
+}
+
+sub run_install ($self, $ctx, $cmd) {
+    local %ENV = %ENV;
+    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($ctx);
+    $self->_set_local_lib_env;
+    $ctx->run_command($cmd, 0);
+}
+
+1;

--- a/lib/App/cpm/Builder/Base.pm
+++ b/lib/App/cpm/Builder/Base.pm
@@ -1,4 +1,4 @@
-package App::cpm::Builder;
+package App::cpm::Builder::Base;
 use v5.24;
 use warnings;
 use experimental qw(signatures);

--- a/lib/App/cpm/Builder/EUMM.pm
+++ b/lib/App/cpm/Builder/EUMM.pm
@@ -1,0 +1,37 @@
+package App::cpm::Builder::EUMM;
+use v5.24;
+use warnings;
+use experimental qw(signatures);
+
+use parent 'App::cpm::Builder';
+
+sub supports ($class, @) {
+    -f 'Makefile.PL';
+}
+
+sub configure ($self, $ctx) {
+    if (!$ctx->{make}) {
+        $ctx->log("There is Makefile.PL, but you don't have 'make' command; you should install 'make' command first");
+        return;
+    }
+    my @cmd = ($ctx->{perl}, 'Makefile.PL');
+    push @cmd, "INSTALL_BASE=$self->{install_base}" if $self->{install_base};
+    push @cmd, qw(INSTALLMAN1DIR=none INSTALLMAN3DIR=none) if $self->{need_noman_argv};
+    push @cmd, 'PUREPERL_ONLY=1' if $self->{pureperl_only};
+    push @cmd, $self->{argv}->@* if $self->{argv}->@*;
+    $self->run_configure($ctx, \@cmd) && -f 'Makefile';
+}
+
+sub build ($self, $ctx) {
+    $self->run_build($ctx, [ $ctx->{make} ]);
+}
+
+sub test ($self, $ctx) {
+    $self->run_test($ctx, [ $ctx->{make}, "test" ]);
+}
+
+sub install ($self, $ctx) {
+    $self->run_install($ctx, [ $ctx->{make}, "install" ]);
+}
+
+1;

--- a/lib/App/cpm/Builder/EUMM.pm
+++ b/lib/App/cpm/Builder/EUMM.pm
@@ -3,7 +3,7 @@ use v5.24;
 use warnings;
 use experimental qw(signatures);
 
-use parent 'App::cpm::Builder';
+use parent 'App::cpm::Builder::Base';
 
 sub supports ($class, @) {
     -f 'Makefile.PL';

--- a/lib/App/cpm/Builder/MB.pm
+++ b/lib/App/cpm/Builder/MB.pm
@@ -3,7 +3,7 @@ use v5.24;
 use warnings;
 use experimental qw(signatures);
 
-use parent 'App::cpm::Builder';
+use parent 'App::cpm::Builder::Base';
 
 sub supports ($class, @) {
     -f 'Build.PL';

--- a/lib/App/cpm/Builder/MB.pm
+++ b/lib/App/cpm/Builder/MB.pm
@@ -1,0 +1,33 @@
+package App::cpm::Builder::MB;
+use v5.24;
+use warnings;
+use experimental qw(signatures);
+
+use parent 'App::cpm::Builder';
+
+sub supports ($class, @) {
+    -f 'Build.PL';
+}
+
+sub configure ($self, $ctx) {
+    my @cmd = ($ctx->{perl}, 'Build.PL');
+    push @cmd, "--install_base", $self->{install_base} if $self->{install_base};
+    push @cmd, qw(--config installman1dir= --config installsiteman1dir= --config installman3dir= --config installsiteman3dir=) if $self->{need_noman_argv};
+    push @cmd, '--pureperl-only' if $self->{pureperl_only};
+    push @cmd, $self->{argv}->@* if $self->{argv}->@*;
+    $self->run_configure($ctx, \@cmd) && -f 'Build';
+}
+
+sub build ($self, $ctx) {
+    $self->run_build($ctx, [ $ctx->{perl}, "./Build" ]);
+}
+
+sub test ($self, $ctx) {
+    $self->run_test($ctx, [ $ctx->{perl}, "./Build", "test" ]);
+}
+
+sub install ($self, $ctx) {
+    $self->run_install($ctx, [ $ctx->{perl}, "./Build", "install" ]);
+}
+
+1;

--- a/lib/App/cpm/Builder/Static.pm
+++ b/lib/App/cpm/Builder/Static.pm
@@ -3,133 +3,142 @@ use v5.24;
 use warnings;
 use experimental qw(lexical_subs signatures);
 
-use CPAN::Meta;
-use ExtUtils::Config 0.003;
-use ExtUtils::Helpers 0.020 qw/make_executable split_like_shell man1_pagename man3_pagename detildefy/;
-use ExtUtils::Install qw/pm_to_blib install/;
-use ExtUtils::InstallPaths 0.002;
-use File::Basename qw/dirname/;
+use ExtUtils::Config;
+use ExtUtils::Helpers qw(make_executable man1_pagename man3_pagename);
+use ExtUtils::Install qw(pm_to_blib);
+use ExtUtils::InstallPaths;
+use File::Basename qw(dirname);
 use File::Find ();
-use File::Path qw/mkpath/;
-use File::Spec::Functions qw/catfile catdir rel2abs abs2rel splitdir curdir/;
-use Getopt::Long 2.36 qw/GetOptionsFromArray/;
+use File::Path qw(mkpath);
+use File::Spec::Functions qw(abs2rel catdir catfile rel2abs);
+use parent 'App::cpm::Builder';
 
-sub read_file {
-	my ($filename) = @_;
-	open my $fh, '<', $filename or die "Could not open $filename: $!\n";
-	return do { local $/; <$fh> };
+my sub find_files ($pattern, $dir) {
+    my @files;
+    File::Find::find(sub {
+        return if !-f;
+        push @files, $File::Find::name if /$pattern/;
+    }, $dir) if -d $dir;
+    return @files;
 }
 
-sub new {
-    my($class, %args) = @_;
-    bless {
-        meta => $args{meta},
-    }, $class;
+my sub read_file ($filename) {
+    open my $fh, '<', $filename or die "Could not open $filename: $!\n";
+    return do { local $/; <$fh> };
 }
 
-sub meta {
-    my $self = shift;
-    $self->{meta};
+my sub contains_pod ($file) {
+    return if !-T $file;
+    return read_file($file) =~ /^\=(?:head|pod|item)/m;
 }
 
-sub manify {
-	my ($input_file, $output_file, $section, $opts) = @_;
-	return if -e $output_file && -M $input_file <= -M $output_file;
-	my $dirname = dirname($output_file);
-	mkpath($dirname, $opts->{verbose}) if not -d $dirname;
-	require Pod::Man;
-	Pod::Man->new(section => $section)->parse_from_file($input_file, $output_file);
-	print "Manifying $output_file\n" if $opts->{verbose} && $opts->{verbose} > 0;
-	return;
+my sub manify ($input_file, $output_file, $section) {
+    return if -e $output_file && -M $input_file <= -M $output_file;
+    my $dirname = dirname($output_file);
+    mkpath($dirname) if !-d $dirname;
+    require Pod::Man;
+    Pod::Man->new(section => $section)->parse_from_file($input_file, $output_file);
+    return;
 }
 
-sub find {
-	my ($pattern, $dir) = @_;
-	my @ret;
-	File::Find::find(sub { push @ret, $File::Find::name if /$pattern/ && -f }, $dir) if -d $dir;
-	return @ret;
+my sub script_files () {
+    return (
+        grep { !/\.pod\z/ } find_files(qr/.+/, 'script'),
+    );
 }
 
-sub contains_pod {
-	my ($file) = @_;
-	return unless -T $file;
-	return read_file($file) =~ /^\=(?:head|pod|item)/m;
+my sub script_doc_files () {
+    return (
+        grep { /\.pod\z/ } find_files(qr/.+/, 'script'),
+    );
 }
 
-my %actions = (
-	build => sub {
-		my %opt = @_;
-		my %modules = map { $_ => catfile('blib', $_) } find(qr/\.pm$/, 'lib');
-		my %docs    = map { $_ => catfile('blib', $_) } find(qr/\.pod$/, 'lib');
-		my %scripts = map { $_ => catfile('blib', $_) } find(qr/(?:)/, 'script');
-		my %sdocs   = map { $_ => delete $scripts{$_} } grep { /.pod$/ } keys %scripts;
-		my %dist_shared    = map { $_ => catfile(qw/blib lib auto share dist/, $opt{meta}->name, abs2rel($_, 'share')) } find(qr/(?:)/, 'share');
-		my %module_shared  = map { $_ => catfile(qw/blib lib auto share module/, abs2rel($_, 'module-share')) } find(qr/(?:)/, 'module-share');
-		pm_to_blib({ %modules, %docs, %scripts, %dist_shared, %module_shared }, catdir(qw/blib lib auto/));
-		make_executable($_) for values %scripts;
-		mkpath(catdir(qw/blib arch/), $opt{verbose});
-
-		if ($opt{install_paths}->install_destination('bindoc') && $opt{install_paths}->is_default_installable('bindoc')) {
-			my $section = $opt{config}->get('man1ext');
-			for my $input (keys %scripts, keys %sdocs) {
-				next unless contains_pod($input);
-				my $output = catfile('blib', 'bindoc', man1_pagename($input));
-				manify($input, $output, $section, \%opt);
-			}
-		}
-		if ($opt{install_paths}->install_destination('libdoc') && $opt{install_paths}->is_default_installable('libdoc')) {
-			my $section = $opt{config}->get('man3ext');
-			for my $input (keys %modules, keys %docs) {
-				next unless contains_pod($input);
-				my $output = catfile('blib', 'libdoc', man3_pagename($input));
-				manify($input, $output, $section, \%opt);
-			}
-		}
-                1;
-	},
-	test => sub {
-		my %opt = @_;
-		die "Must run `./Build build` first\n" if not -d 'blib';
-		require TAP::Harness::Env;
-		my %test_args = (
-			(verbosity => $opt{verbose}) x!! exists $opt{verbose},
-			(jobs => $opt{jobs}) x!! exists $opt{jobs},
-			(color => 1) x !!-t STDOUT,
-			lib => [ map { rel2abs(catdir(qw/blib/, $_)) } qw/arch lib/ ],
-		);
-		my $tester = TAP::Harness::Env->create(\%test_args);
-		$tester->runtests(sort +find(qr/\.t$/, 't'))->has_errors and return;
-                1;
-	},
-	install => sub {
-		my %opt = @_;
-		die "Must run `./Build build` first\n" if not -d 'blib';
-		install($opt{install_paths}->install_map, @opt{qw/verbose dry_run uninst/});
-                1;
-	},
-);
-
-sub build {
-	my $self = shift;
-	my $action = @_ && $_[0] =~ /\A\w+\z/ ? shift @_ : 'build';
-	die "No such action '$action'\n" if not $actions{$action};
-	my %opt;
-	GetOptionsFromArray([@$_], \%opt, qw/install_base=s install_path=s% installdirs=s destdir=s prefix=s config=s% uninst:1 verbose:1 dry_run:1 pureperl-only:1 create_packlist=i jobs=i/) for ($self->{env}, $self->{configure_args}, \@_);
-	$_ = detildefy($_) for grep { defined } @opt{qw/install_base destdir prefix/}, values %{ $opt{install_path} };
-	@opt{ 'config', 'meta' } = (ExtUtils::Config->new($opt{config}), $self->meta);
-	$actions{$action}->(%opt, install_paths => ExtUtils::InstallPaths->new(%opt, dist_name => $opt{meta}->name));
+my sub share_files ($dist_name) {
+    return (
+        map { $_ => catfile(qw(blib lib auto share dist), $dist_name, abs2rel($_, 'share')) }
+            find_files(qr/.+/, 'share'),
+        map { $_ => catfile(qw(blib lib auto share module), abs2rel($_, 'module-share')) }
+            find_files(qr/.+/, 'module-share'),
+    );
 }
 
-sub configure {
-	my $self = shift;   
-	$self->{env} = defined $ENV{PERL_MB_OPT} ? [split_like_shell($ENV{PERL_MB_OPT})] : [];
-        $self->{configure_args} = [@_];
-	$self->meta->save(@$_) for ['MYMETA.json'], [ 'MYMETA.yml' => { version => 1.4 } ];
+my sub build_manpages ($install_paths, $config, $modules, $scripts) {
+    if ($install_paths->install_destination('bindoc') && $install_paths->is_default_installable('bindoc')) {
+        my $section = $config->get('man1ext');
+        for my $input ($scripts->@*, script_doc_files()) {
+            next if !contains_pod($input);
+            manify($input, catfile('blib', 'bindoc', man1_pagename($input)), $section);
+        }
+    }
+    if ($install_paths->install_destination('libdoc') && $install_paths->is_default_installable('libdoc')) {
+        my $section = $config->get('man3ext');
+        for my $input ($modules->@*) {
+            next if !contains_pod($input);
+            manify($input, catfile('blib', 'libdoc', man3_pagename($input)), $section);
+        }
+    }
+}
+
+sub supports ($class, $meta) {
+    return $meta->{x_static_install} && $meta->{x_static_install} == 1;
+}
+
+sub configure ($self, $ctx) {
+    $self->meta->save(@$_) for ['MYMETA.json'], [ 'MYMETA.yml' => { version => 1.4 } ];
+    return 1;
+}
+
+sub build ($self, $ctx) {
+    $self->run_build($ctx, sub {
+        my @modules = find_files(qr/\.(?:pm|pod)\z/, 'lib');
+        my @scripts = script_files();
+        my %files = (
+            (map { $_ => catfile('blib', $_) } @modules),
+            (map { $_ => catfile('blib', $_) } @scripts),
+            share_files($self->meta->name),
+        );
+        pm_to_blib(\%files, catdir(qw(blib lib auto)));
+        make_executable($_) for grep { m{\Ablib/script/} } values %files;
+        mkpath(catdir(qw(blib arch)));
+        build_manpages($self->_install_paths, ExtUtils::Config->new, \@modules, \@scripts) if $self->{man_pages};
+        return 1;
+    });
+}
+
+sub test ($self, $ctx) {
+    $self->run_test($ctx, sub {
+        return 1 if !-d 't';
+
+        require TAP::Harness::Env;
+        my $tester = TAP::Harness::Env->create({
+            color => -t STDOUT ? 1 : 0,
+            lib => [ map { rel2abs(catdir(qw(blib), $_)) } qw(arch lib) ],
+        });
+        return !$tester->runtests(sort find_files(qr/\.t\z/, 't'))->has_errors;
+    });
+}
+
+sub install ($self, $ctx) {
+    $self->run_install($ctx, sub {
+        die "Must run build first\n" if !-d 'blib';
+        ExtUtils::Install::install($self->_install_paths->install_map, 0, 0, 0);
+        return 1;
+    });
+}
+
+sub _install_paths ($self) {
+    ExtUtils::InstallPaths->new(
+        dist_name => $self->meta->name,
+        ($self->{install_base} ? (install_base => $self->{install_base}) : ()),
+    );
 }
 
 1;
 
 =head1 COPYRIGHT AND LICENSE
+
+This module is based on L<Module::Build::Tiny|https://metacpan.org/dist/Module-Build-Tiny>.
+Its COPYRIGHT AND LICENSE is:
 
 This software is copyright (c) 2011 by Leon Timmermans, David Golden.
 

--- a/lib/App/cpm/Builder/Static.pm
+++ b/lib/App/cpm/Builder/Static.pm
@@ -11,7 +11,7 @@ use File::Basename qw(dirname);
 use File::Find ();
 use File::Path qw(mkpath);
 use File::Spec::Functions qw(abs2rel catdir catfile rel2abs);
-use parent 'App::cpm::Builder';
+use parent 'App::cpm::Builder::Base';
 
 my sub find_files ($pattern, $dir) {
     my @files;

--- a/lib/App/cpm/Builder/Static.pm
+++ b/lib/App/cpm/Builder/Static.pm
@@ -11,6 +11,7 @@ use File::Basename qw(dirname);
 use File::Find ();
 use File::Path qw(mkpath);
 use File::Spec::Functions qw(abs2rel catdir catfile rel2abs);
+
 use parent 'App::cpm::Builder::Base';
 
 my sub find_files ($pattern, $dir) {
@@ -90,17 +91,17 @@ sub configure ($self, $ctx) {
 
 sub build ($self, $ctx) {
     $self->run_build($ctx, sub {
-        my @modules = find_files(qr/\.(?:pm|pod)\z/, 'lib');
-        my @scripts = script_files();
-        my %files = (
-            (map { $_ => catfile('blib', $_) } @modules),
-            (map { $_ => catfile('blib', $_) } @scripts),
+        my @module = find_files(qr/\.(?:pm|pod)\z/, 'lib');
+        my @script = script_files();
+        my %file = (
+            (map { $_ => catfile('blib', $_) } @module),
+            (map { $_ => catfile('blib', $_) } @script),
             share_files($self->meta->name),
         );
-        pm_to_blib(\%files, catdir(qw(blib lib auto)));
-        make_executable($_) for grep { m{\Ablib/script/} } values %files;
+        pm_to_blib(\%file, catdir(qw(blib lib auto)));
+        make_executable($_) for grep { m{\Ablib/script/} } values %file;
         mkpath(catdir(qw(blib arch)));
-        build_manpages($self->_install_paths, ExtUtils::Config->new, \@modules, \@scripts) if $self->{man_pages};
+        build_manpages($self->_install_paths, ExtUtils::Config->new, \@module, \@script) if $self->{man_pages};
         return 1;
     });
 }
@@ -108,7 +109,6 @@ sub build ($self, $ctx) {
 sub test ($self, $ctx) {
     $self->run_test($ctx, sub {
         return 1 if !-d 't';
-
         require TAP::Harness::Env;
         my $tester = TAP::Harness::Env->create({
             color => -t STDOUT ? 1 : 0,
@@ -120,7 +120,6 @@ sub test ($self, $ctx) {
 
 sub install ($self, $ctx) {
     $self->run_install($ctx, sub {
-        die "Must run build first\n" if !-d 'blib';
         ExtUtils::Install::install($self->_install_paths->install_map, 0, 0, 0);
         return 1;
     });

--- a/lib/App/cpm/CLI.pm
+++ b/lib/App/cpm/CLI.pm
@@ -27,11 +27,9 @@ use File::Copy ();
 use File::Path ();
 use File::Spec;
 use Getopt::Long qw(:config no_auto_abbrev no_ignore_case bundling);
-use List::Util ();
 use Module::CPANfile;
 use Module::cpmfile;
 use Parallel::Pipes::App;
-use Pod::Text ();
 
 sub new ($class, %argv) {
     my $prebuilt = exists $ENV{PERL_CPM_PREBUILT} && !$ENV{PERL_CPM_PREBUILT} ? 0 : 1;

--- a/lib/App/cpm/Distribution.pm
+++ b/lib/App/cpm/Distribution.pm
@@ -52,7 +52,7 @@ for my $attr (qw(
     uri
     provides
     ref
-    static_builder
+    builder
     prebuilt
 )) {
     no strict 'refs';

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -240,7 +240,7 @@ sub _calculate_tasks ($self, $ctx) {
                     directory => $dist->directory,
                     distfile => $dist->{distfile},
                     uri => $dist->uri,
-                    static_builder => $dist->static_builder,
+                    builder => $dist->builder,
                     prebuilt => $dist->prebuilt,
                     provides => $dist->provides,
                 );
@@ -458,7 +458,7 @@ sub _register_configure_result ($self, $ctx, $task) {
     my $distribution = $self->distribution($task->distfile);
     $distribution->configured(1);
     $distribution->requirements($_ => $task->{requirements}{$_}) for keys $task->{requirements}->%*;
-    $distribution->static_builder($task->{static_builder});
+    $distribution->builder($task->{builder});
     return 1;
 }
 

--- a/lib/App/cpm/Worker/Installer.pm
+++ b/lib/App/cpm/Worker/Installer.pm
@@ -346,35 +346,20 @@ sub configure_builder ($self, $ctx, $meta) {
         my ($class, $argv) = $candidate->@*;
         next if !$class->supports($meta);
 
-        my $builder = eval {
-            $class->new(
-                meta => $meta,
-                local_lib => $self->{local_lib},
-                install_base => $self->{local_lib} || $self->{implicit_install_base},
-                need_noman_argv => $self->{need_noman_argv},
-                man_pages => $self->{man_pages},
-                pureperl_only => $self->{pureperl_only},
-                argv => $argv,
-                configure_timeout => $self->{configure_timeout},
-                build_timeout => $self->{build_timeout},
-                test_timeout => $self->{test_timeout},
-            );
-        };
-        if (!$builder) {
-            chomp(my $error = $@ || "unknown error");
-            $ctx->log("$class failed to initialize: $error");
-            next;
-        }
+        my $builder = $class->new(
+            meta => $meta,
+            local_lib => $self->{local_lib},
+            install_base => $self->{local_lib} || $self->{implicit_install_base},
+            need_noman_argv => $self->{need_noman_argv},
+            man_pages => $self->{man_pages},
+            pureperl_only => $self->{pureperl_only},
+            argv => $argv,
+            configure_timeout => $self->{configure_timeout},
+            build_timeout => $self->{build_timeout},
+            test_timeout => $self->{test_timeout},
+        );
 
-        my $ok = $self->_retry($ctx, sub () {
-            my $configured = eval { $builder->configure($ctx) };
-            if (!$configured) {
-                chomp(my $error = $@ || "configure failed");
-                $ctx->log("$class failed to configure: $error");
-                return;
-            }
-            return 1;
-        });
+        my $ok = $self->_retry($ctx, sub () { $builder->configure($ctx) });
         return $builder if $ok;
     }
     return;

--- a/lib/App/cpm/Worker/Installer.pm
+++ b/lib/App/cpm/Worker/Installer.pm
@@ -3,6 +3,8 @@ use v5.24;
 use warnings;
 use experimental qw(lexical_subs signatures);
 
+use App::cpm::Builder::EUMM;
+use App::cpm::Builder::MB;
 use App::cpm::Builder::Static;
 use App::cpm::Requirement;
 use App::cpm::Util;
@@ -51,7 +53,7 @@ sub work ($self, $ctx, $task) {
             return +{
                 ok => 1,
                 requirements => $result->{requirements},
-                static_builder => $result->{static_builder},
+                builder => $result->{builder},
             };
         } else {
             $ctx->log("Failed to configure distribution");
@@ -321,141 +323,61 @@ sub configure ($self, $ctx, $task) {
     my ($dir, $distfile, $meta, $source) = $task->@{qw(directory distfile meta source)};
     my $guard = pushd $dir;
 
-    my $install_base = $self->{local_lib} || $self->{implicit_install_base};
     $ctx->log("Configuring distribution");
-    my ($static_builder, $configure_ok);
-    {
-        if ($self->opts_in_static_install($ctx, $meta)) {
-            $static_builder = $self->static_install_configure($ctx, $meta);
-            ++$configure_ok and last;
-        }
-        if (-f 'Build.PL') {
-            my @cmd = ($ctx->{perl}, 'Build.PL');
-            push @cmd, "--install_base", $install_base if $install_base;
-            push @cmd, qw(--config installman1dir= --config installsiteman1dir= --config installman3dir= --config installsiteman3dir=) if $self->{need_noman_argv};
-            push @cmd, '--pureperl-only' if $self->{pureperl_only};
-            push @cmd, $self->{mb_argv}->@* if $self->{mb_argv}->@*;
-            $self->_retry($ctx, sub () {
-                $self->_configure($ctx, \@cmd, $meta);
-                -f 'Build';
-            }) and ++$configure_ok and last;
-        }
-        if (-f 'Makefile.PL') {
-            if (!$ctx->{make}) {
-                $ctx->log("There is Makefile.PL, but you don't have 'make' command; you should install 'make' command first");
-                last;
-            }
-            my @cmd = ($ctx->{perl}, 'Makefile.PL');
-            push @cmd, "INSTALL_BASE=$install_base" if $install_base;
-            push @cmd, qw(INSTALLMAN1DIR=none INSTALLMAN3DIR=none) if $self->{need_noman_argv};
-            push @cmd, 'PUREPERL_ONLY=1' if $self->{pureperl_only};
-            push @cmd, $self->{eumm_argv}->@* if $self->{eumm_argv}->@*;
-            $self->_retry($ctx, sub () {
-                $self->_configure($ctx, \@cmd, $meta);
-                -f 'Makefile';
-            }) and ++$configure_ok and last;
-        }
-    }
-    return if !$configure_ok;
+    my $builder = $self->configure_builder($ctx, $meta);
+    return if !$builder;
 
     my $phase = $self->{notest} ? [qw(build runtime)] : [qw(build test runtime)];
     my $mymeta = $self->_load_metafile($ctx, $distfile, 'MYMETA.json', 'MYMETA.yml');
     my $req = $self->_extract_requirements($ctx, $mymeta, $phase);
     return +{
         requirements => $req,
-        static_builder => $static_builder,
+        builder => $builder,
     };
 }
 
-sub _local_lib_env_path ($self, $ctx) {
-    join $Config{path_sep}, File::Spec->catdir($self->{local_lib}, "bin"), ( $ENV{PATH} ? $ENV{PATH} : () );
-}
+sub configure_builder ($self, $ctx, $meta) {
+    my @candidates = (
+        ($self->{static_install} ? [ 'App::cpm::Builder::Static', $self->{mb_argv} ] : ()),
+        [ 'App::cpm::Builder::MB',     $self->{mb_argv} ],
+        [ 'App::cpm::Builder::EUMM',   $self->{eumm_argv} ],
+    );
+    for my $candidate (@candidates) {
+        my ($class, $argv) = $candidate->@*;
+        next if !$class->supports($meta);
 
-sub _local_lib_env_perl5lib ($self, $ctx) {
-    join $Config{path_sep}, File::Spec->catdir($self->{local_lib}, "lib", "perl5"), ( $ENV{PERL5LIB} ? $ENV{PERL5LIB} : ());
-}
+        my $builder = eval {
+            $class->new(
+                meta => $meta,
+                local_lib => $self->{local_lib},
+                install_base => $self->{local_lib} || $self->{implicit_install_base},
+                need_noman_argv => $self->{need_noman_argv},
+                man_pages => $self->{man_pages},
+                pureperl_only => $self->{pureperl_only},
+                argv => $argv,
+                configure_timeout => $self->{configure_timeout},
+                build_timeout => $self->{build_timeout},
+                test_timeout => $self->{test_timeout},
+            );
+        };
+        if (!$builder) {
+            chomp(my $error = $@ || "unknown error");
+            $ctx->log("$class failed to initialize: $error");
+            next;
+        }
 
-sub _configure ($self, $ctx, $cmd, $meta) {
-    local %ENV = %ENV;
-    $ENV{PERL5_CPAN_IS_RUNNING} = $$;
-    $ENV{PERL5_CPANPLUS_IS_RUNNING} = $$;
-    $ENV{PERL5_CPANM_IS_RUNNING} = $$;
-    $ENV{PERL_MM_USE_DEFAULT} = 1;
-    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($ctx, $meta);
-    if ($self->{local_lib}) {
-        $ENV{PATH} = $self->_local_lib_env_path($ctx);
-        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib($ctx);
+        my $ok = $self->_retry($ctx, sub () {
+            my $configured = eval { $builder->configure($ctx) };
+            if (!$configured) {
+                chomp(my $error = $@ || "configure failed");
+                $ctx->log("$class failed to configure: $error");
+                return;
+            }
+            return 1;
+        });
+        return $builder if $ok;
     }
-    $ctx->run_command($cmd, $self->{configure_timeout});
-}
-
-sub static_install_configure ($self, $ctx, $meta) {
-    my $builder = App::cpm::Builder::Static->new(meta => $meta);
-    my @argv;
-    if (my $install_base = $self->{local_lib} || $self->{implicit_install_base}) {
-        push @argv, "--install_base", $install_base;
-    }
-    if ($self->{need_noman_argv}) {
-        push @argv, qw(--config installman1dir= --config installsiteman1dir= --config installman3dir= --config installsiteman3dir=);
-    }
-    if ($self->{pureperl_only}) {
-        push @argv, '--pureperl-only';
-    }
-    if ($self->{mb_argv}->@*) {
-        push @argv, $self->{mb_argv}->@*;
-    }
-    local %ENV = %ENV;
-    if ($self->{local_lib}) {
-        $ENV{PATH} = $self->_local_lib_env_path($ctx);
-        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib($ctx);
-    }
-    $builder->configure(@argv);
-    return $builder;
-}
-
-
-sub _build ($self, $ctx, $cmd, $meta) {
-    local %ENV = %ENV;
-    $ENV{PERL_MM_USE_DEFAULT} = 1;
-    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($ctx, $meta);
-    if ($self->{local_lib}) {
-        $ENV{PATH} = $self->_local_lib_env_path($ctx);
-        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib($ctx);
-    }
-    $ctx->run_command($cmd, $self->{build_timeout});
-}
-
-sub _test ($self, $ctx, $cmd, $meta) {
-    local %ENV = %ENV;
-    $ENV{PERL_MM_USE_DEFAULT} = 1;
-    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($ctx, $meta);
-    $ENV{NONINTERACTIVE_TESTING} = 1;
-    if ($self->{local_lib}) {
-        $ENV{PATH} = $self->_local_lib_env_path($ctx);
-        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib($ctx);
-    }
-    $ctx->run_command($cmd, $self->{test_timeout});
-}
-
-sub _install ($self, $ctx, $cmd, $meta) {
-    local %ENV = %ENV;
-    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($ctx, $meta);
-    if ($self->{local_lib}) {
-        $ENV{PATH} = $self->_local_lib_env_path($ctx);
-        $ENV{PERL5LIB} = $self->_local_lib_env_perl5lib($ctx);
-    }
-    $ctx->run_command($cmd, 0);
-}
-
-sub _use_unsafe_inc ($self, $ctx, $meta) {
-    if (exists $ENV{PERL_USE_UNSAFE_INC}) {
-        return $ENV{PERL_USE_UNSAFE_INC};
-    }
-    if (exists $meta->{x_use_unsafe_inc}) {
-        $ctx->log("Distribution opts in x_use_unsafe_inc: $meta->{x_use_unsafe_inc}"); # XXX
-        return $meta->{x_use_unsafe_inc};
-    }
-    1;
+    return;
 }
 
 sub opts_in_static_install ($self, $ctx, $meta) {
@@ -466,28 +388,16 @@ sub opts_in_static_install ($self, $ctx, $meta) {
 sub install ($self, $ctx, $task) {
     return $self->install_prebuilt($ctx, $task) if $task->{prebuilt};
 
-    my ($dir, $static_builder, $distvname, $meta, $provides, $distfile)
-        = $task->@{qw(directory static_builder distvname meta provides distfile)};
+    my ($dir, $builder, $distvname, $meta, $provides, $distfile)
+        = $task->@{qw(directory builder distvname meta provides distfile)};
     my $guard = pushd $dir;
 
     $ctx->log("Building " . ($self->{notest} ? "" : "and testing ") . "distribution");
     my $installed;
-    if ($static_builder) {
-        $self->_build($ctx, sub () { $static_builder->build }, $meta)
-        && ($self->{notest} || $self->_test($ctx, sub () { $static_builder->build("test") }, $meta))
-        && $self->_install($ctx, sub () { $static_builder->build("install") }, $meta)
-        && $installed++;
-    } elsif (-f 'Build') {
-        $self->_retry($ctx, sub () { $self->_build($ctx, [ $ctx->{perl}, "./Build" ], $meta)  })
-        && ($self->{notest} || $self->_retry($ctx, sub () { $self->_test($ctx, [ $ctx->{perl}, "./Build", "test" ], $meta) }))
-        && $self->_retry($ctx, sub () { $self->_install($ctx, [ $ctx->{perl}, "./Build", "install" ], $meta)  })
-        && $installed++;
-    } else {
-        $self->_retry($ctx, sub () { $self->_build($ctx, [ $ctx->{make} ], $meta)  })
-        && ($self->{notest} || $self->_retry($ctx, sub () { $self->_test($ctx, [ $ctx->{make}, "test" ], $meta) }))
-        && $self->_retry($ctx, sub () { $self->_install($ctx, [ $ctx->{make}, "install" ], $meta) })
-        && $installed++;
-    }
+    $self->_retry($ctx, sub () { $builder->build($ctx) })
+    && ($self->{notest} || $self->_retry($ctx, sub () { $builder->test($ctx) }))
+    && $self->_retry($ctx, sub () { $builder->install($ctx) })
+    && $installed++;
 
     if ($installed && $distfile) {
         $self->save_meta($ctx, $meta, $distfile, $provides);

--- a/lib/App/cpm/Worker/Installer.pm
+++ b/lib/App/cpm/Worker/Installer.pm
@@ -337,12 +337,12 @@ sub configure ($self, $ctx, $task) {
 }
 
 sub configure_builder ($self, $ctx, $meta) {
-    my @candidates = (
+    my @candidate = (
         ($self->{static_install} ? [ 'App::cpm::Builder::Static', $self->{mb_argv} ] : ()),
         [ 'App::cpm::Builder::MB',     $self->{mb_argv} ],
         [ 'App::cpm::Builder::EUMM',   $self->{eumm_argv} ],
     );
-    for my $candidate (@candidates) {
+    for my $candidate (@candidate) {
         my ($class, $argv) = $candidate->@*;
         next if !$class->supports($meta);
 


### PR DESCRIPTION
## Summary

This refactors installer build handling into builder classes under App::cpm::Builder.

- Add App::cpm::Builder::Base, EUMM, and MB
- Convert Static into the same builder interface while keeping static install behavior and manpage generation
- Store the selected builder on Distribution
- Make Worker::Installer select a builder during configure and call builder methods during install

## Validation

- prove -l t xt