### PR TITLE
Refine install-last final installation and compatibility options

### DIFF
--- a/author/DEV.md
+++ b/author/DEV.md
@@ -254,6 +254,53 @@ Two user-facing escape hatches now exist:
 
 These are mainly for compatibility and transition, not because they are preferred as the long-term default.
 
+### 7. Large prebuilt installs were made fast again
+
+The install-last branch introduced a serious slowdown for large installs.
+
+Benchmark command used during investigation:
+
+```console
+rm -rf local && perl -Ilib script/cpm install $(cat ~/modules)
+```
+
+Both sides used prebuilt artifacts.
+
+Observed numbers on the test machine:
+
+- `c2ad7fd`: about 18.5 seconds for 858 installed distributions
+- install-last branch before optimization: about 205 seconds
+- after optimization: about 22 seconds
+
+Two hot spots caused most of the regression.
+
+First, final install called `dependency_env_for($dist, [qw(configure build runtime)])`
+for every selected distribution.
+
+That is required only when using build-system install commands such as:
+
+- `make install`
+- `./Build install`
+
+Normal final install from `blib`, including prebuilt install, does not need dependency
+`PERL5LIB` / `PATH`.
+
+Builders now expose `needs_install_env`.
+Only `Builder::EUMM` and `Builder::MB` return true when `--use-install-command`
+is enabled.
+
+Second, `_resolved_distribution` repeatedly scanned all distributions while checking
+dependency readiness and while building dependency environments.
+
+The result is now cached by package and version range.
+The cache is cleared in `add_distribution` whenever the distribution/provides set changes.
+
+Important future rule:
+
+- do not add broad `dependency_env_for` calls to final install unless the install path really needs dependency environment
+- if distribution/provides data becomes mutable in another place, clear `_resolved_distribution` there too
+- be careful when caching `dependency_env_for` itself, because its result depends on `dependency_ready`
+
 ## Summary
 
 The large refactor after `e01d6db` reached its main target:

--- a/author/DEV.md
+++ b/author/DEV.md
@@ -11,7 +11,7 @@ Concretely:
 - move build-system-specific logic into builder classes
 - separate `configure`, `build`, `test`, and final `install`
 - stop relying on partially populated `local/lib` during the build graph
-- let distributions become usable before final installation
+- let distributions become dependency-ready before final installation
 - make final installation a simple last phase
 
 Another intended goal is to narrow what gets finally installed by default.
@@ -97,26 +97,26 @@ Separate scheduler flags:
 - `registered`
 - `deps_registered`
 
-Separate derived flag:
+Separate graph-derived readiness in `App::cpm::Master`:
 
-- `usable`
+- `dependency_ready`
 
-`usable` means:
+`dependency_ready` means:
 
-- under `--notest`: the distribution is built and its dependency closure is usable
-- under `--test`: the distribution is tested and its dependency closure is usable
+- under `--notest`: the distribution is built and its runtime dependency closure is dependency-ready
+- under `--test`: the distribution is tested and can be used as a dependency
 
 This replaces the old habit of using `installed` as the only practical dependency gate.
 
 ### 5. Scheduler became fixed-point based
 
-Because `usable` is derived state, one scheduler pass is not enough.
+Because dependency readiness is derived state, one scheduler pass is not enough.
 
 `App::cpm::Master` now repeatedly adds tasks until no further change occurs.
 
 This is needed for chains like:
 
-- dependency becomes `usable`
+- dependency becomes dependency-ready
 - that enables another distribution to `build`
 - that later enables another distribution to `test`
 
@@ -157,7 +157,7 @@ Prebuilt is now represented by `App::cpm::Builder::Prebuilt`.
 Current prebuilt behavior:
 
 - prebuilt is treated as already built
-- scheduler uses it via `usable`
+- scheduler uses it via `dependency_ready`
 - final install uses the same builder install path as other builders
 
 ### 9. Logging/progress changed to match install-last
@@ -190,68 +190,67 @@ The current design is roughly:
 1. resolve dependencies
 2. fetch sources / prebuilt artifacts
 3. configure/build/test through builders
-4. mark distributions `usable`
+4. mark distributions dependency-ready
 5. once the graph is done, perform final install
 
 This is the intended direction of the refactor, and at this point it is implemented end-to-end.
 
-## Remaining Issues
+## Resolved Release Issues
 
-### 1. `usable` is a practical compromise, not a perfect model
+### 1. Dependency readiness is now Master-owned
 
-`usable` lives on `Distribution`, but it is not a pure lifecycle state.
-It is derived from the dependency graph.
+The old `usable` flag has been removed from `Distribution`.
+Distribution now keeps lifecycle state only.
 
-This is workable, but it still mixes:
+Graph-derived readiness now lives in `App::cpm::Master` as `dependency_ready`.
 
-- self state
-- graph-derived readiness
+This keeps:
 
-more than ideal.
+- distribution lifecycle state
+- scheduler bookkeeping
+- graph-derived dependency readiness
 
-### 2. `installed` still exists mostly for bookkeeping
+separate enough for the version 1.0.0 model.
 
-Final install still marks distributions as `installed`, and some reporting/failure paths still use that.
+### 2. `installed` is final-install bookkeeping
 
-This is acceptable for now, but it is no longer the conceptual center of dependency progression.
+Final install still marks distributions as `installed`, but dependency progression no longer depends on it.
+It is used only for final install reporting and failure accounting.
 
-### 3. Final install UX can still improve
+### 3. Final install UX remains separate
 
 With install-last, users may see a long build/test period and only later final placement.
 
-That is conceptually correct, but terminal UX may still need refinement.
+Terminal logging for the final install phase is intentionally left for separate UX work.
+The per-distribution `Successfully installed distribution` log remains in `build.log`.
 
-Desired work here:
+### 4. `CPAN::Meta::Spec` phase rules follow the spec
 
-- revisit terminal logging
-- make the install phase easier to understand while it is waiting for build/test to finish
-- make the final install phase easier to understand when it starts
+Build scheduling treats runtime dependencies as prerequisites for the build phase.
+This is not ideal from a modeling perspective, but it follows `CPAN::Meta::Spec`.
 
-### 4. `CPAN::Meta::Spec` phase rules still deserve review
+The current phase gates are:
 
-The current code was changed to follow the spec more closely, especially around cumulative phase requirements.
+- configure: `configure`
+- build: `configure`, `runtime`, `build`
+- test: `configure`, `build`, `runtime`, `test`
+- dependency readiness under `--no-test`: `runtime`
 
-However, the requirement that `runtime` deps are considered before `build` still looks questionable from a modeling perspective and may deserve an upstream issue/discussion.
+### 5. Partial-success final install policy is implemented
 
-### 5. Partial-success final install policy is still open
+If some distributions fail, final install still installs distributions that:
 
-Current install-last behavior does not try to preserve the old “install whatever already succeeded along the way” behavior.
+- succeeded far enough to be dependency-ready
+- are selected for final installation
 
-This is deliberate for now, but the policy is still open if practical use suggests a different tradeoff.
+The overall `cpm install` command still fails if any selected distribution or resolve step failed.
 
-The current desired direction is:
+### 6. Compatibility / escape hatches were added
 
-- if some distributions fail, still install the distributions that have succeeded and are selected for final installation
-- but the overall `cpm install` command should still be treated as failed
+Two user-facing escape hatches now exist:
 
-### 6. Compatibility / escape hatches still need work
-
-This branch changed behavior in large ways.
-
-User-facing escape hatches are still wanted:
-
-- an option to do install via `make install` / `./Build install`
-- an option to install everything as before, not only direct targets plus runtime dependencies
+- `--use-install-command`: use `make install` / `./Build install` when available, with dependency `PERL5LIB` / `PATH`
+- `--install-all`: final-install every dependency-ready distribution
 
 These are mainly for compatibility and transition, not because they are preferred as the long-term default.
 
@@ -262,6 +261,6 @@ The large refactor after `e01d6db` reached its main target:
 - builder-driven build pipeline
 - install-last execution
 - common final installation from built artifacts
-- dependency progression based on `usable`, not `installed`
+- dependency progression based on `dependency_ready`, not `installed`
 
-The remaining work is mostly refinement, cleanup, and policy, not the original architectural change.
+The remaining work for 1.0.0 is release mechanics and broader verification, not the original architectural change.

--- a/lib/App/cpm/Builder/Base.pm
+++ b/lib/App/cpm/Builder/Base.pm
@@ -160,6 +160,10 @@ sub install ($self, $ctx, $dependency_libs = [], $dependency_paths = []) {
     return 1;
 }
 
+sub needs_install_env ($self) {
+    return 0;
+}
+
 sub _log_env ($self, $ctx) {
     if (exists $ENV{PERL5LIB}) {
         $ctx->log("PERL5LIB: $_") for split /\Q$Config{path_sep}\E/, $ENV{PERL5LIB};

--- a/lib/App/cpm/Builder/Base.pm
+++ b/lib/App/cpm/Builder/Base.pm
@@ -154,7 +154,7 @@ sub _install_blib_meta ($self, $ctx) {
     return 1;
 }
 
-sub install ($self, $ctx) {
+sub install ($self, $ctx, $dependency_libs = [], $dependency_paths = []) {
     $self->_install_blib($ctx);
     $self->_install_blib_meta($ctx);
     return 1;
@@ -199,6 +199,15 @@ sub run_build ($self, $ctx, $cmd, $dependency_libs, $dependency_paths) {
     $self->_set_env($dependency_libs, $dependency_paths);
     DEBUG and $self->_log_env($ctx);
     $ctx->run_command($cmd, $self->{build_timeout});
+}
+
+sub run_install ($self, $ctx, $cmd, $dependency_libs, $dependency_paths) {
+    local %ENV = %ENV;
+    $ENV{PERL_MM_USE_DEFAULT} = 1;
+    $ENV{PERL_USE_UNSAFE_INC} = $self->_use_unsafe_inc($ctx);
+    $self->_set_env($dependency_libs, $dependency_paths);
+    DEBUG and $self->_log_env($ctx);
+    $ctx->run_command($cmd, 0);
 }
 
 sub run_test ($self, $ctx, $cmd, $dependency_libs, $dependency_paths) {

--- a/lib/App/cpm/Builder/EUMM.pm
+++ b/lib/App/cpm/Builder/EUMM.pm
@@ -34,4 +34,12 @@ sub test ($self, $ctx, $dependency_libs, $dependency_paths) {
     $self->run_test($ctx, [ $ctx->{make}, "test" ], $dependency_libs, $dependency_paths);
 }
 
+sub install ($self, $ctx, $dependency_libs = [], $dependency_paths = []) {
+    return $self->SUPER::install($ctx, $dependency_libs, $dependency_paths) if !$self->{use_install_command};
+    my $ok = $self->run_install($ctx, [ $ctx->{make}, "install" ], $dependency_libs, $dependency_paths);
+    return if !$ok;
+    $self->_install_blib_meta($ctx);
+    return 1;
+}
+
 1;

--- a/lib/App/cpm/Builder/EUMM.pm
+++ b/lib/App/cpm/Builder/EUMM.pm
@@ -42,4 +42,8 @@ sub install ($self, $ctx, $dependency_libs = [], $dependency_paths = []) {
     return 1;
 }
 
+sub needs_install_env ($self) {
+    return $self->{use_install_command} ? 1 : 0;
+}
+
 1;

--- a/lib/App/cpm/Builder/MB.pm
+++ b/lib/App/cpm/Builder/MB.pm
@@ -30,4 +30,12 @@ sub test ($self, $ctx, $dependency_libs, $dependency_paths) {
     $self->run_test($ctx, [ $ctx->{perl}, "./Build", "test" ], $dependency_libs, $dependency_paths);
 }
 
+sub install ($self, $ctx, $dependency_libs = [], $dependency_paths = []) {
+    return $self->SUPER::install($ctx, $dependency_libs, $dependency_paths) if !$self->{use_install_command};
+    my $ok = $self->run_install($ctx, [ $ctx->{perl}, "./Build", "install" ], $dependency_libs, $dependency_paths);
+    return if !$ok;
+    $self->_install_blib_meta($ctx);
+    return 1;
+}
+
 1;

--- a/lib/App/cpm/Builder/MB.pm
+++ b/lib/App/cpm/Builder/MB.pm
@@ -38,4 +38,8 @@ sub install ($self, $ctx, $dependency_libs = [], $dependency_paths = []) {
     return 1;
 }
 
+sub needs_install_env ($self) {
+    return $self->{use_install_command} ? 1 : 0;
+}
+
 1;

--- a/lib/App/cpm/CLI.pm
+++ b/lib/App/cpm/CLI.pm
@@ -60,6 +60,8 @@ sub new ($class, %argv) {
         prebuilt => $prebuilt,
         pureperl_only => 0,
         static_install => 1,
+        install_all => 0,
+        use_install_command => 0,
         default_resolvers => 1,
         %argv
     }, $class;
@@ -103,6 +105,8 @@ sub parse_options ($self, @argv) {
         "reinstall" => \($self->{reinstall}),
         "pp|pureperl|pureperl-only" => \($self->{pureperl_only}),
         "static-install!" => \($self->{static_install}),
+        "install-all!" => \($self->{install_all}),
+        "use-install-command!" => \($self->{use_install_command}),
         "with-all" => sub (@) { map { $self->{"with_$_"} = 1 } @type, @phase },
         (map $with_option->($_), @type),
         (map $with_option->($_), @phase),
@@ -278,6 +282,7 @@ sub cmd_install ($self) {
         global => $self->{global},
         notest => $self->{notest},
         show_progress => $self->{show_progress},
+        install_all => $self->{install_all},
         (exists $self->{target_perl} ? (target_perl => $self->{target_perl}) : ()),
     );
 
@@ -296,6 +301,7 @@ sub cmd_install ($self) {
         prebuilt  => $self->{prebuilt},
         pureperl_only => $self->{pureperl_only},
         static_install => $self->{static_install},
+        use_install_command => $self->{use_install_command},
         configure_timeout => $self->{configure_timeout},
         build_timeout     => $self->{build_timeout},
         test_timeout      => $self->{test_timeout},
@@ -305,7 +311,8 @@ sub cmd_install ($self) {
         mb_argv => $mb_argv,
     );
 
-    $master->add_task($ctx, type => "resolve", $_->%*) for $packages->@*;
+    $master->add_task($ctx, type => "resolve", final_target => 1, $_->%*) for $packages->@*;
+    $_->final_target(1) for $dists->@*;
     $master->add_distribution($_) for $dists->@*;
     $self->install($ctx, $master, $worker, $self->{workers});
     $master->install_distributions($ctx);
@@ -317,8 +324,10 @@ sub cmd_install ($self) {
         }
     }
     print STDERR "\r" if $self->{show_progress};
-    warn sprintf "%d distribution%s installed.\n",
-        $master->installed_distributions, $master->installed_distributions > 1 ? "s" : "";
+    my $installed = $master->installed_distributions;
+    warn $self->{install_all}
+        ? sprintf("%d distribution%s installed.\n", $installed, $installed > 1 ? "s" : "")
+        : sprintf("%d distribution%s installed (the runtime dependency closure only).\n", $installed, $installed > 1 ? "s" : "");
     $self->cleanup;
 
     if ($fail) {
@@ -745,6 +754,13 @@ Options:
         prefer pureperl only build
       --static-install, --no-static-install
         enable/disable the static install, default: enable
+      --install-all, --no-install-all
+        install every successfully built distribution, including build/test-only dependencies.
+        by default, cpm installs only the runtime dependency closure.
+        default: off
+      --use-install-command, --no-use-install-command
+        use make install or ./Build install for final installation when available.
+        default: off
   -r, --resolver=class,args (EXPERIMENTAL, will be removed or renamed)
         specify resolvers, you can use --resolver multiple times
         available classes: metadb/metacpan/02packages/snapshot

--- a/lib/App/cpm/Distribution.pm
+++ b/lib/App/cpm/Distribution.pm
@@ -27,7 +27,6 @@ sub new ($class, %argv) {
         distfile => $distfile,
         source => $source,
         _state => STATE_RESOLVED,
-        usable => 0,
         registered => 0,
         deps_registered => 0,
         requirements => {},
@@ -63,6 +62,7 @@ for my $attr (qw(
     ref
     builder
     prebuilt
+    final_target
 )) {
     no strict 'refs';
     *$attr = sub ($self, @argv) {
@@ -103,11 +103,6 @@ sub registered ($self, @argv) {
 sub deps_registered ($self, @argv) {
     $self->{deps_registered} = $argv[0] ? 1 : 0 if @argv;
     $self->{deps_registered};
-}
-
-sub usable ($self, @argv) {
-    $self->{usable} = $argv[0] ? 1 : 0 if @argv;
-    $self->{usable};
 }
 
 sub resolved ($self, @argv) {

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -190,7 +190,11 @@ sub dependency_ready ($self, $dist, @argv) {
 }
 
 sub _resolved_distribution ($self, $package, $version_range = undef) {
+    my $key = join "\0", $package, $version_range // "";
+    return $self->{_resolved_distribution}{$key} if exists $self->{_resolved_distribution}{$key};
+
     my ($resolved) = grep { $_->providing($package, $version_range) } $self->distributions;
+    $self->{_resolved_distribution}{$key} = $resolved;
     $resolved;
 }
 
@@ -260,7 +264,9 @@ sub install_distributions ($self, $ctx) {
 
         local $ctx->{logger}{context} = $dist->distvname;
         $ctx->log("Installing distribution");
-        my $env = $self->dependency_env_for($dist, [qw(configure build runtime)]);
+        my $env = $dist->builder->needs_install_env
+            ? $self->dependency_env_for($dist, [qw(configure build runtime)])
+            : { dependency_libs => [], dependency_paths => [] };
         my $ok = $dist->builder->install($ctx, $env->{dependency_libs}, $env->{dependency_paths});
         if ($ok) {
             $dist->installed(1);
@@ -617,10 +623,12 @@ sub add_distribution ($self, $distribution) {
     if (my $already = $self->{distributions}{$distfile}) {
         if ($already->resolved) {
             $already->overwrite_provide($_) for $distribution->provides->@*;
+            delete $self->{_resolved_distribution};
         }
         return 0;
     } else {
         $self->{distributions}{$distfile} = $distribution;
+        delete $self->{_resolved_distribution};
         return 1;
     }
 }

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -19,6 +19,7 @@ sub new ($class, %argv) {
         installed_distributions => 0,
         tasks => +{},
         distributions => +{},
+        dependency_ready => +{},
         _fail_resolve => +{},
         _fail_install => +{},
         _is_installed => +{},
@@ -50,7 +51,7 @@ sub new ($class, %argv) {
 sub fail ($self, $ctx) {
     my @fail_resolve = sort keys $self->{_fail_resolve}->%*;
     my @fail_install = sort keys $self->{_fail_install}->%*;
-    my @not_installed = grep { !$self->{_fail_install}{$_->distfile} && !$_->installed } $self->distributions;
+    my @not_installed = grep { !$self->{_fail_install}{$_->distfile} && !$_->installed } $self->_final_install_distributions(1);
     return if !@fail_resolve && !@fail_install && !@not_installed;
 
     my $detector = App::cpm::CircularDependency->new;
@@ -93,7 +94,8 @@ sub tasks ($self) { values $self->{tasks}->%* }
 
 sub add_task ($self, $ctx, %task) {
     my $new = App::cpm::Task->new(%task);
-    if (grep { $_->equals($new) } $self->tasks) {
+    if (my ($existing) = grep { $_->equals($new) } $self->tasks) {
+        $existing->{final_target} ||= $new->{final_target};
         return 0;
     } else {
         $self->{tasks}{$new->uid} = $new;
@@ -181,6 +183,12 @@ sub install_phase_state ($self, $dist) {
     return $self->{notest} ? "built" : "tested";
 }
 
+sub dependency_ready ($self, $dist, @argv) {
+    my $distfile = $dist->distfile;
+    $self->{dependency_ready}{$distfile} = $argv[0] ? 1 : 0 if @argv;
+    $self->{dependency_ready}{$distfile};
+}
+
 sub _resolved_distribution ($self, $package, $version_range = undef) {
     my ($resolved) = grep { $_->providing($package, $version_range) } $self->distributions;
     $resolved;
@@ -200,7 +208,7 @@ sub dependency_env_for ($self, $dist, $phases, $seen = undef, $found = undef) {
             next if $self->is_installed($package, $version_range);
             next;
         }
-        next if !$resolved->usable;
+        next if !$self->dependency_ready($resolved);
         next if $seen->{$resolved->distfile}++;
 
         $found->{$resolved->distfile} = $resolved;
@@ -219,17 +227,32 @@ sub dependency_env_for ($self, $dist, $phases, $seen = undef, $found = undef) {
     };
 }
 
-sub _install_env_phases ($self, $dist) {
-    return [qw(runtime)] if $dist->prebuilt;
-    return $self->{notest}
-        ? [qw(configure runtime build)]
-        : [qw(configure runtime build test)];
+sub _final_install_distributions ($self, $include_unready = 0) {
+    return grep { $include_unready || $self->dependency_ready($_) } $self->distributions if $self->{install_all};
+
+    my %seen;
+    my @todo = grep { $_->final_target } $self->distributions;
+    my @install;
+    while (my $dist = shift @todo) {
+        next if $seen{$dist->distfile}++;
+        push @install, $dist if $include_unready || $self->dependency_ready($dist);
+
+        for my $req ($dist->requirements('runtime')->as_array->@*) {
+            my ($package, $version_range) = $req->@{qw(package version_range)};
+            next if $package eq "perl";
+            next if $self->{target_perl} and $self->is_core($package, $version_range);
+
+            my $resolved = $self->_resolved_distribution($package, $version_range);
+            next if !$resolved;
+            next if $self->is_installed($package, $version_range);
+            push @todo, $resolved;
+        }
+    }
+    return @install;
 }
 
 sub install_distributions ($self, $ctx) {
-    return if $self->{_fail_resolve}->%* || $self->{_fail_install}->%*;
-
-    my @dist = grep { $_->usable } $self->distributions;
+    my @dist = $self->_final_install_distributions;
     return if !@dist;
 
     for my $dist (sort { $a->distvname cmp $b->distvname } @dist) {
@@ -237,7 +260,8 @@ sub install_distributions ($self, $ctx) {
 
         local $ctx->{logger}{context} = $dist->distvname;
         $ctx->log("Installing distribution");
-        my $ok =$dist->builder->install($ctx);
+        my $env = $self->dependency_env_for($dist, [qw(configure build runtime)]);
+        my $ok = $dist->builder->install($ctx, $env->{dependency_libs}, $env->{dependency_paths});
         if ($ok) {
             $dist->installed(1);
             $self->{installed_distributions}++;
@@ -270,9 +294,9 @@ sub _add_tasks ($self, $ctx) {
         my $changed = 0;
 
         if ($self->{notest}) {
-            $changed += $self->_mark_built_usable($ctx);
+            $changed += $self->_mark_built_dependency_ready($ctx);
         } else {
-            $changed += $self->_mark_tested_usable($ctx);
+            $changed += $self->_mark_tested_dependency_ready($ctx);
         }
 
         $changed += $self->_add_fetch_tasks($ctx);
@@ -287,15 +311,15 @@ sub _add_tasks ($self, $ctx) {
     }
 }
 
-sub _mark_built_usable ($self, $ctx) {
+sub _mark_built_dependency_ready ($self, $ctx) {
     my $changed = 0;
     my @distributions = grep { !$self->{_fail_install}{$_->distfile} } $self->distributions;
-    if (my @dists = grep { $_->built && !$_->usable } @distributions) {
+    if (my @dists = grep { $_->built && !$self->dependency_ready($_) } @distributions) {
         for my $dist (@dists) {
             my $dist_requirements = $dist->requirements('runtime')->as_array;
             my ($is_satisfied, @need_resolve) = $self->is_satisfied($dist_requirements);
             if ($is_satisfied) {
-                $dist->usable(1);
+                $self->dependency_ready($dist, 1);
                 $changed++;
             } elsif (!defined $is_satisfied) {
                 local $ctx->{logger}{context} = $dist->distvname;
@@ -321,10 +345,10 @@ sub _mark_built_usable ($self, $ctx) {
     return $changed;
 }
 
-sub _mark_tested_usable ($self, $ctx) {
+sub _mark_tested_dependency_ready ($self, $ctx) {
     my @distributions = grep { !$self->{_fail_install}{$_->distfile} } $self->distributions;
-    my @dists = grep { $_->tested && !$_->usable } @distributions;
-    $_->usable(1) for @dists;
+    my @dists = grep { $_->tested && !$self->dependency_ready($_) } @distributions;
+    $self->dependency_ready($_, 1) for @dists;
     return scalar @dists;
 }
 
@@ -447,7 +471,7 @@ sub _add_test_tasks ($self, $ctx) {
     if (my @dists = grep { $_->built && !$_->registered } @distributions) {
         for my $dist (@dists) {
             local $ctx->{logger}{context} = $dist->distvname;
-            my @phase = qw(configure runtime build test);
+            my @phase = qw(configure build runtime test);
             my $dist_requirements = $dist->requirements(\@phase)->as_array;
             my ($is_satisfied, @need_resolve) = $self->is_satisfied($dist_requirements);
             if ($is_satisfied) {
@@ -575,7 +599,7 @@ sub is_satisfied ($self, $requirements) {
         next if $self->{target_perl} and $self->is_core($package, $version_range);
         my $resolved = $self->_resolved_distribution($package, $version_range);
         if ($resolved) {
-            next if $resolved->usable;
+            next if $self->dependency_ready($resolved);
         } else {
             next if $self->is_installed($package, $version_range);
         }
@@ -649,8 +673,11 @@ sub _register_resolve_result ($self, $ctx, $task) {
         provides => $provides,
         distfile => $task->{distfile},
         ref      => $task->{ref},
+        final_target => $task->{final_target},
     );
-    $self->add_distribution($distribution);
+    if (!$self->add_distribution($distribution) && $task->{final_target}) {
+        $self->distribution($distribution->distfile)->final_target(1);
+    }
 }
 
 sub _register_fetch_result ($self, $ctx, $task) {

--- a/lib/App/cpm/Worker/Installer.pm
+++ b/lib/App/cpm/Worker/Installer.pm
@@ -363,6 +363,7 @@ sub configure_builder ($self, $ctx, $task) {
             need_noman_argv => $self->{need_noman_argv},
             man_pages => $self->{man_pages},
             pureperl_only => $self->{pureperl_only},
+            use_install_command => $self->{use_install_command},
             argv => $argv,
             configure_timeout => $self->{configure_timeout},
             build_timeout => $self->{build_timeout},

--- a/xt/10_basic.t
+++ b/xt/10_basic.t
@@ -64,7 +64,7 @@ subtest distfile => sub () {
 subtest use_install_command => sub () {
     my $r = cpm_install "--use-install-command", "ExtUtils::Config\@0.008";
     is $r->exit, 0;
-    like $r->log, qr/ExtUtils-Config-0\.008\| Executing .+make install/;
+    like $r->log, qr/ExtUtils-Config-0\.008\| Executing .+(?:g?make(?:\.EXE)?|nmake(?:\.exe)?) install/i;
 };
 
 subtest configure => sub () {

--- a/xt/10_basic.t
+++ b/xt/10_basic.t
@@ -2,6 +2,7 @@ use v5.24;
 use warnings;
 use experimental qw(lexical_subs signatures);
 
+use File::Spec;
 use Test::More;
 use lib "xt/lib";
 use CLI;
@@ -26,6 +27,22 @@ subtest test => sub () {
     };
 };
 
+subtest final_install_selection => sub () {
+    my $installed = sub ($local, $path) {
+        -f File::Spec->catfile($local, "lib", "perl5", split "/", $path);
+    };
+
+    my $r = cpm_install "--test", "Data::Section::Simple";
+    is $r->exit, 0;
+    ok $installed->($r->local, "Data/Section/Simple.pm");
+    ok !$installed->($r->local, "Test/Requires.pm");
+
+    $r = cpm_install "--test", "--install-all", "Data::Section::Simple";
+    is $r->exit, 0;
+    ok $installed->($r->local, "Data/Section/Simple.pm");
+    ok $installed->($r->local, "Test/Requires.pm");
+};
+
 subtest range => sub () {
     my $r = cpm_install "CPAN::Test::Dummy::Perl5::Deps::VersionRange";
     is $r->exit, 0;
@@ -42,6 +59,12 @@ subtest distfile => sub () {
     my $r = cpm_install "LEONT/ExtUtils-Config-0.008.tar.gz";
     is $r->exit, 0;
     like $r->log, qr/ExtUtils-Config-0\.008\| Successfully installed distribution/;
+};
+
+subtest use_install_command => sub () {
+    my $r = cpm_install "--use-install-command", "ExtUtils::Config\@0.008";
+    is $r->exit, 0;
+    like $r->log, qr/ExtUtils-Config-0\.008\| Executing .+make install/;
 };
 
 subtest configure => sub () {

--- a/xt/28_timeout.t
+++ b/xt/28_timeout.t
@@ -9,7 +9,7 @@ my $r = cpm_install "--configure-timeout", 2,
     "https://github.com/skaji/CPAN-Test-Dummy-Perl5-SleepSteps.git",
     "File::pushd";
 isnt $r->exit, 0;
-# like $r->err, qr{DONE install File-pushd};
+like $r->log, qr/File-pushd-[^\|]+\| Successfully installed distribution/;
 like $r->err, qr{FAIL install https://github.com/skaji/CPAN-Test-Dummy-Perl5-SleepSteps.git};
 like $r->err, qr{See .* for details};
 

--- a/xt/31_circular_dep.t
+++ b/xt/31_circular_dep.t
@@ -7,7 +7,7 @@ use CLI;
 
 my $r = cpm_install 'CPAN::Test::Dummy::Perl5::Make::CircDepeOne', 'File::pushd';
 isnt $r->exit, 0;
-# like $r->err, qr{DONE install File-pushd};
+like $r->log, qr/File-pushd-[^\|]+\| Successfully installed distribution/;
 like $r->err, qr/FAIL install CPAN-Test-Dummy-Perl5-Make-CircDepeOne/;
 like $r->err, qr/FAIL install CPAN-Test-Dummy-Perl5-Make-CircDepeThree/;
 like $r->err, qr/FAIL install CPAN-Test-Dummy-Perl5-Make-CircDepeTwo/;

--- a/xt/36_fail.t
+++ b/xt/36_fail.t
@@ -1,6 +1,7 @@
 use v5.24;
 use warnings;
 use experimental qw(lexical_subs signatures);
+use File::Spec;
 use Test::More;
 
 use lib "xt/lib";
@@ -13,6 +14,14 @@ with_same_local {
     my @log = split /\r?\n/, $r->log;
     like $log[-2], qr/The direct cause of the failure/;
     like $log[-1], qr/CPAN-Test-Dummy-Perl5-Build-Fails-\d/;
+};
+
+with_same_local {
+    cpm_install 'Module::Build';
+    my $r = cpm_install '--test', 'Data::Section::Simple', 'CPAN::Test::Dummy::Perl5::Build::DepeFails';
+    isnt $r->exit, 0;
+    ok -f File::Spec->catfile($r->local, qw(lib perl5 Data Section Simple.pm));
+    like $r->err, qr/1 distribution installed/;
 };
 
 done_testing;


### PR DESCRIPTION
## Summary
Refine install-last final installation for the 1.0 release path.

## What changed
- add `--install-all` to keep the old "install every successful distribution" path available
- add `--use-install-command` to allow `make install` / `Build install` for compatibility
- change final installation so successful distributions are still installed even if another target fails
- tighten the install-last implementation and related tests around these behaviors

## Why
The install-last refactor changes when and how distributions are finally installed. This PR makes the default behavior clearer, restores compatibility escape hatches, and avoids throwing away successful builds when one distribution fails.
