### PR TITLE
Split install-all tests

### DIFF
--- a/xt/10_basic.t
+++ b/xt/10_basic.t
@@ -27,22 +27,6 @@ subtest test => sub () {
     };
 };
 
-subtest final_install_selection => sub () {
-    my $installed = sub ($local, $path) {
-        -f File::Spec->catfile($local, "lib", "perl5", split "/", $path);
-    };
-
-    my $r = cpm_install "--test", "Data::Section::Simple";
-    is $r->exit, 0;
-    ok $installed->($r->local, "Data/Section/Simple.pm");
-    ok !$installed->($r->local, "Test/Requires.pm");
-
-    $r = cpm_install "--test", "--install-all", "Data::Section::Simple";
-    is $r->exit, 0;
-    ok $installed->($r->local, "Data/Section/Simple.pm");
-    ok $installed->($r->local, "Test/Requires.pm");
-};
-
 subtest range => sub () {
     my $r = cpm_install "CPAN::Test::Dummy::Perl5::Deps::VersionRange";
     is $r->exit, 0;

--- a/xt/39_install_all.t
+++ b/xt/39_install_all.t
@@ -1,0 +1,51 @@
+use v5.24;
+use warnings;
+use experimental qw(lexical_subs signatures);
+
+use File::Spec;
+use Test::More;
+use lib "xt/lib";
+use CLI;
+use Path::Tiny;
+
+subtest direct_target => sub () {
+    my $installed = sub ($local, $path) {
+        -f File::Spec->catfile($local, "lib", "perl5", split "/", $path);
+    };
+
+    my $r = cpm_install "--test", "Data::Section::Simple";
+    is $r->exit, 0;
+    ok $installed->($r->local, "Data/Section/Simple.pm");
+    ok !$installed->($r->local, "Test/Requires.pm");
+
+    $r = cpm_install "--test", "--install-all", "Data::Section::Simple";
+    is $r->exit, 0;
+    ok $installed->($r->local, "Data/Section/Simple.pm");
+    ok $installed->($r->local, "Test/Requires.pm");
+};
+
+subtest cpmfile => sub () {
+    my $cpmfile = Path::Tiny->tempfile;
+    $cpmfile->spew(<<'EOF');
+prereqs:
+    runtime:
+        requires:
+            CPAN::Test::Dummy::Perl5::ModuleBuild: { version: '== 0.001' }
+EOF
+
+    my $installed = sub ($local, $path) {
+        -f path($local, "lib", "perl5", split "/", $path);
+    };
+
+    my $r = cpm_install "--cpmfile", $cpmfile;
+    is $r->exit, 0;
+    ok $installed->($r->local, "CPAN/Test/Dummy/Perl5/ModuleBuild.pm");
+    ok !$installed->($r->local, "Module/Build.pm");
+
+    $r = cpm_install "--install-all", "--cpmfile", $cpmfile;
+    is $r->exit, 0;
+    ok $installed->($r->local, "CPAN/Test/Dummy/Perl5/ModuleBuild.pm");
+    ok $installed->($r->local, "Module/Build.pm");
+};
+
+done_testing;


### PR DESCRIPTION
Move install-all coverage into xt/39_install_all.t and add a cpm.yml case that checks build-time dependencies stay out of the default final install.