### PR TITLE
Handle narrow tty progress output

### DIFF
--- a/lib/App/cpm/CLI.pm
+++ b/lib/App/cpm/CLI.pm
@@ -13,7 +13,7 @@ use App::cpm::Requirement;
 use App::cpm::Resolver::Cascade;
 use App::cpm::Resolver::MetaCPAN;
 use App::cpm::Resolver::MetaDB;
-use App::cpm::Util qw(WIN32 determine_home maybe_abs);
+use App::cpm::Util qw(WIN32 determine_home maybe_abs terminal_width);
 use App::cpm::Worker;
 use App::cpm::version;
 use App::cpm;
@@ -74,7 +74,7 @@ sub _normalize_progress ($self, $progress) {
 }
 
 sub _progress_default ($self) {
-    !WIN32 && !$ENV{CI} && !$self->{verbose} && -t STDERR ? "tty" : "plain";
+    !WIN32 && !$ENV{CI} && !$self->{verbose} && -t STDERR && terminal_width > 60 ? "tty" : "plain";
 }
 
 sub parse_options ($self, @argv) {
@@ -393,7 +393,7 @@ sub install ($self, $ctx, $master, $worker, $num) {
         num => $num,
         init_work => sub ($pipes) {
             my @pid = sort { $a <=> $b } keys $pipes->{pipes}->%*;
-            $master->enable_terminal_logger(@pid) if $tty_progress;
+            $master->enable_terminal_logger(pids => \@pid, width => terminal_width) if $tty_progress;
             $master->{terminal_logger}->use_color($self->{color}) if $tty_progress;
         },
         before_work => sub ($task, $pipe, @) {

--- a/lib/App/cpm/Logger/Terminal.pm
+++ b/lib/App/cpm/Logger/Terminal.pm
@@ -17,21 +17,33 @@ package App::cpm::Logger::Terminal::_Lines {
         install   => "installing",
     );
 
-    sub new ($class, $pids, $progress, $use_color) {
+    sub new ($class, $pids, $progress, $use_color, $width) {
         my $num = keys $pids->%*;
         bless {
             pids => $pids,
             progress => $progress,
             num => $num,
             use_color => $use_color,
+            width => $width,
             _lines => [],
         }, $class;
+    }
+
+    sub _truncate ($self, $text, $width) {
+        return "" if $width <= 0;
+        return $text if length($text) <= $width;
+        return "." x $width if $width <= 3;
+        substr($text, 0, $width - 3) . "...";
     }
 
     sub set_worker ($self, $pid, $task = undef) {
         my ($progress, $ing, $name) = $task
             ? ($self->{progress}, $ING{$task->type} || $task->type, $task->distvname)
             : (" ", "idle", "");
+        if ($self->{width}) {
+            my $available = $self->{width} - 14;
+            $name = $self->_truncate($name, $available);
+        }
         $ing = sprintf "%-11s", $ing;
         $ing = "\e[1;30m$ing\e[m" if $self->{use_color};
         $self->{_lines}[ $self->{pids}{$pid} ] = sprintf "%s %-11s %s\n",
@@ -47,7 +59,8 @@ package App::cpm::Logger::Terminal::_Lines {
     }
 }
 
-sub new ($class, @pid) {
+sub new ($class, %argv) {
+    my @pid = $argv{pids}->@*;
     my %pid = map { ($pid[$_], $_) } 0 .. $#pid;
     bless {
         first => 1,
@@ -56,6 +69,7 @@ sub new ($class, @pid) {
         fh => \*STDERR,
         progress_index => 0,
         use_color => 1,
+        width => $argv{width} || 0,
     }, $class;
 }
 
@@ -72,7 +86,7 @@ sub progress ($self) {
 }
 
 sub new_lines ($self) {
-    App::cpm::Logger::Terminal::_Lines->new($self->{pids}, $self->progress, $self->{use_color});
+    App::cpm::Logger::Terminal::_Lines->new($self->{pids}, $self->progress, $self->{use_color}, $self->{width});
 }
 
 sub clear ($self) {

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -159,8 +159,8 @@ sub info ($self, $task) {
     return 1;
 }
 
-sub enable_terminal_logger ($self, @pid) {
-    $self->{terminal_logger} = App::cpm::Logger::Terminal->new(@pid);
+sub enable_terminal_logger ($self, %argv) {
+    $self->{terminal_logger} = App::cpm::Logger::Terminal->new(%argv);
 }
 
 sub _terminal_summary_count ($self) {

--- a/lib/App/cpm/Util.pm
+++ b/lib/App/cpm/Util.pm
@@ -12,7 +12,7 @@ use IO::Uncompress::Gunzip ();
 
 use Exporter 'import';
 
-our @EXPORT_OK = qw(DEBUG perl_identity maybe_abs WIN32 determine_home gunzip bunzip2 uniq);
+our @EXPORT_OK = qw(DEBUG perl_identity maybe_abs WIN32 determine_home gunzip bunzip2 uniq terminal_width);
 
 use constant DEBUG => $ENV{PERL_CPM_DEBUG} ? 1 : 0;
 use constant WIN32 => $^O eq 'MSWin32';
@@ -42,6 +42,14 @@ sub determine_home () { # taken from Menlo
     }
 
     File::Spec->catdir($homedir, ".perl-cpm");
+}
+
+sub terminal_width () {
+    my $request = $^O eq 'linux' ? 0x5413 : 0x40087468;
+    my $winsize = pack("S4", 0, 0, 0, 0);
+    return 0 if !ioctl(\*STDERR, $request, $winsize);
+    my (undef, $cols, undef, undef) = unpack("S4", $winsize);
+    $cols || 0;
 }
 
 sub gunzip ($from, $to) {


### PR DESCRIPTION
Handle narrow terminal widths in `--progress=tty` mode by preferring `plain` in `auto` mode for narrow terminals and truncating long distribution names in the tty UI.

This issue was reported by @thibaultduponchelle ++.