### PR TITLE
Refine install command environment handling

### DIFF
--- a/lib/App/cpm/Builder/Base.pm
+++ b/lib/App/cpm/Builder/Base.pm
@@ -65,23 +65,23 @@ sub paths ($self) {
 sub _env_path ($self, $dependency_paths) {
     join $Config{path_sep},
         $dependency_paths->@*,
-        ($self->local_lib ? File::Spec->catdir($self->local_lib, "bin") : ()),
+        ($self->{local_bin} ? $self->{local_bin} : ()),
         ( $ENV{PATH} ? $ENV{PATH} : () );
 }
 
 sub _env_perl5lib ($self, $dependency_libs) {
     join $Config{path_sep},
         $dependency_libs->@*,
-        ($self->local_lib ? File::Spec->catdir($self->local_lib, "lib", "perl5") : ()),
+        ($self->{local_perl5lib} ? $self->{local_perl5lib} : ()),
         ( $ENV{PERL5LIB} ? $ENV{PERL5LIB} : ());
 }
 
 sub _set_env ($self, $dependency_libs, $dependency_paths) {
-    if ($dependency_paths->@* || $self->local_lib) {
+    if ($dependency_paths->@* || $self->{local_bin}) {
         $ENV{PATH} = $self->_env_path($dependency_paths);
     }
 
-    if ($dependency_libs->@* || $self->local_lib) {
+    if ($dependency_libs->@* || $self->{local_perl5lib}) {
         $ENV{PERL5LIB} = $self->_env_perl5lib($dependency_libs);
     }
 }

--- a/lib/App/cpm/Builder/EUMM.pm
+++ b/lib/App/cpm/Builder/EUMM.pm
@@ -15,7 +15,7 @@ sub configure ($self, $ctx, $dependency_libs, $dependency_paths) {
         return;
     }
     my @cmd = ($ctx->{perl}, 'Makefile.PL');
-    push @cmd, "INSTALL_BASE=$self->{install_base}" if $self->{install_base};
+    push @cmd, "INSTALL_BASE=$self->{install_base}" if $self->{use_install_command} && $self->{install_base};
     push @cmd, qw(INSTALLMAN1DIR=none INSTALLMAN3DIR=none) if $self->{need_noman_argv};
     push @cmd, 'PUREPERL_ONLY=1' if $self->{pureperl_only};
     push @cmd, $self->{argv}->@* if $self->{argv}->@*;

--- a/lib/App/cpm/Builder/MB.pm
+++ b/lib/App/cpm/Builder/MB.pm
@@ -11,7 +11,7 @@ sub supports ($class, @) {
 
 sub configure ($self, $ctx, $dependency_libs, $dependency_paths) {
     my @cmd = ($ctx->{perl}, 'Build.PL');
-    push @cmd, "--install_base", $self->{install_base} if $self->{install_base};
+    push @cmd, "--install_base", $self->{install_base} if $self->{use_install_command} && $self->{install_base};
     push @cmd, qw(--config installman1dir= --config installsiteman1dir= --config installman3dir= --config installsiteman3dir=) if $self->{need_noman_argv};
     push @cmd, '--pureperl-only' if $self->{pureperl_only};
     push @cmd, $self->{argv}->@* if $self->{argv}->@*;

--- a/lib/App/cpm/CLI.pm
+++ b/lib/App/cpm/CLI.pm
@@ -211,7 +211,7 @@ sub parse_options ($self, @argv) {
     if (WIN32 and $self->{workers} != 1) {
         die "The number of workers must be 1 under WIN32 environment.\n";
     }
-    if ($self->{pureperl_only} or !$self->{notest} or $self->{man_pages}) {
+    if ($self->{pureperl_only} or !$self->{notest} or $self->{man_pages} or $self->{use_install_command}) {
         $self->{prebuilt} = 0;
     }
 
@@ -603,9 +603,9 @@ sub locate_dependency_file ($self) {
             my $base = App::cpm::Util::maybe_abs($self->{local_lib});
             $ENV{PATH} = join $Config{path_sep}, File::Spec->catdir($base, "bin"), ( $ENV{PATH} ? $ENV{PATH} : () );
             $ENV{PERL5LIB} = join $Config{path_sep}, File::Spec->catdir($base, "lib", "perl5"), ( $ENV{PERL5LIB} ? $ENV{PERL5LIB} : ());
-            if ($build_file eq "Makefile.PL") {
+            if ($self->{use_install_command} && $build_file eq "Makefile.PL") {
                 push @cmd, "INSTALL_BASE=$base";
-            } else {
+            } elsif ($self->{use_install_command}) {
                 push @cmd, "--install_base", $base;
             }
         }
@@ -834,7 +834,7 @@ Options:
       --prebuilt, --no-prebuilt
         save builds for CPAN distributions; and later, install the prebuilts if available
         default: on; you can also set $ENV{PERL_CPM_PREBUILT} false to disable this option.
-        usage of --test and/or --man-pages disables this option.
+        usage of --test, --man-pages, and/or --use-install-command disables this option.
       --target-perl=VERSION  (EXPERIMENTAL)
         install modules as if version is your perl is VERSION
       --mirror=URL

--- a/lib/App/cpm/Worker/Installer.pm
+++ b/lib/App/cpm/Worker/Installer.pm
@@ -80,6 +80,10 @@ sub new ($class, $ctx, %argv) {
     mkpath $_ for grep !-d, $argv{work_dir}, $argv{cache_dir};
     if ($argv{local_lib}) {
         $argv{local_lib} = App::cpm::Util::maybe_abs($argv{local_lib});
+        my $local_bin = File::Spec->catdir($argv{local_lib}, "bin");
+        my $local_perl5lib = File::Spec->catdir($argv{local_lib}, "lib", "perl5");
+        $argv{local_bin} = $local_bin if -d $local_bin;
+        $argv{local_perl5lib} = $local_perl5lib if -d $local_perl5lib;
     }
 
     my $need_noman_argv = !$argv{man_pages} &&
@@ -242,6 +246,8 @@ sub find_prebuilt ($self, $ctx, $uri) {
         distfile => $uri,
         provides => $provides,
         local_lib => $self->{local_lib},
+        local_bin => $self->{local_bin},
+        local_perl5lib => $self->{local_perl5lib},
         install_base => $self->{local_lib} || $self->{implicit_install_base},
     );
     return +{
@@ -350,6 +356,8 @@ sub configure_builder ($self, $ctx, $task) {
             distfile => $task->{distfile},
             provides => $task->{provides},
             local_lib => $self->{local_lib},
+            local_bin => $self->{local_bin},
+            local_perl5lib => $self->{local_perl5lib},
             install_base => $self->{local_lib} || $self->{implicit_install_base},
             need_noman_argv => $self->{need_noman_argv},
             man_pages => $self->{man_pages},

--- a/xt/40_cli_options.t
+++ b/xt/40_cli_options.t
@@ -1,0 +1,29 @@
+use v5.24;
+use warnings;
+use experimental qw(signatures);
+
+use Test::More;
+use App::cpm::CLI;
+
+subtest use_install_command_disables_prebuilt => sub () {
+    my $cli = App::cpm::CLI->new;
+    ok $cli->parse_options("--use-install-command", "ModuleA");
+    is $cli->{use_install_command}, 1;
+    is $cli->{prebuilt}, 0;
+};
+
+subtest use_install_command_disables_explicit_prebuilt => sub () {
+    my $cli = App::cpm::CLI->new;
+    ok $cli->parse_options("--prebuilt", "--use-install-command", "ModuleA");
+    is $cli->{use_install_command}, 1;
+    is $cli->{prebuilt}, 0;
+};
+
+subtest no_use_install_command_keeps_prebuilt => sub () {
+    my $cli = App::cpm::CLI->new;
+    ok $cli->parse_options("--no-use-install-command", "ModuleA");
+    is $cli->{use_install_command}, 0;
+    is $cli->{prebuilt}, 1;
+};
+
+done_testing;

--- a/xt/builder/01_env.t
+++ b/xt/builder/01_env.t
@@ -1,0 +1,53 @@
+use v5.24;
+use warnings;
+use experimental qw(signatures);
+
+use File::Path qw(mkpath);
+use File::Spec;
+use File::Temp qw(tempdir);
+use Test::More;
+use App::cpm::Builder::Base;
+
+subtest absent_local_lib_does_not_set_env => sub () {
+    my $local = File::Spec->catdir(tempdir(CLEANUP => 1), "local");
+    my $builder = App::cpm::Builder::Base->new(distfile => "A-1.0.tar.gz", local_lib => $local);
+
+    local %ENV = ();
+    $builder->_set_env([], []);
+
+    ok !exists $ENV{PERL5LIB};
+    ok !exists $ENV{PATH};
+};
+
+subtest existing_local_lib_paths_are_added => sub () {
+    my $local = File::Spec->catdir(tempdir(CLEANUP => 1), "local");
+    my $bin = File::Spec->catdir($local, "bin");
+    my $lib = File::Spec->catdir($local, "lib", "perl5");
+    mkpath [$bin, $lib];
+
+    my $builder = App::cpm::Builder::Base->new(
+        distfile => "A-1.0.tar.gz",
+        local_lib => $local,
+        local_bin => $bin,
+        local_perl5lib => $lib,
+    );
+
+    local %ENV = ();
+    $builder->_set_env([], []);
+
+    is $ENV{PERL5LIB}, $lib;
+    is $ENV{PATH}, $bin;
+};
+
+subtest dependency_paths_are_still_added_without_local_lib => sub () {
+    my $local = File::Spec->catdir(tempdir(CLEANUP => 1), "local");
+    my $builder = App::cpm::Builder::Base->new(distfile => "A-1.0.tar.gz", local_lib => $local);
+
+    local %ENV = ();
+    $builder->_set_env(["blib/lib"], ["blib/script"]);
+
+    is $ENV{PERL5LIB}, "blib/lib";
+    is $ENV{PATH}, "blib/script";
+};
+
+done_testing;

--- a/xt/builder/02_install_base.t
+++ b/xt/builder/02_install_base.t
@@ -1,0 +1,71 @@
+use v5.24;
+use warnings;
+use experimental qw(signatures);
+
+use Cwd qw(getcwd);
+use File::Temp qw(tempdir);
+use Test::More;
+use App::cpm::Builder::EUMM;
+use App::cpm::Builder::MB;
+
+my @cmd;
+my $cwd = getcwd;
+my $tmpdir = tempdir CLEANUP => 1;
+chdir $tmpdir or die "chdir $tmpdir: $!";
+END { chdir $cwd if defined $cwd }
+
+{
+    no warnings 'redefine';
+    local *App::cpm::Builder::Base::run_configure = sub ($self, $ctx, $cmd, @) {
+        @cmd = $cmd->@*;
+        open my $fh, ">", $ctx->{configured_file} or die $!;
+        close $fh;
+        return 1;
+    };
+
+    subtest eumm_install_base_requires_use_install_command => sub () {
+        my $ctx = { perl => $^X, make => "make", configured_file => "Makefile" };
+
+        unlink "Makefile";
+        App::cpm::Builder::EUMM->new(
+            distfile => "A-1.0.tar.gz",
+            install_base => "/tmp/local",
+            use_install_command => 0,
+            argv => [],
+        )->configure($ctx, [], []);
+        is_deeply \@cmd, [ $^X, "Makefile.PL" ];
+
+        unlink "Makefile";
+        App::cpm::Builder::EUMM->new(
+            distfile => "A-1.0.tar.gz",
+            install_base => "/tmp/local",
+            use_install_command => 1,
+            argv => [],
+        )->configure($ctx, [], []);
+        is_deeply \@cmd, [ $^X, "Makefile.PL", "INSTALL_BASE=/tmp/local" ];
+    };
+
+    subtest mb_install_base_requires_use_install_command => sub () {
+        my $ctx = { perl => $^X, configured_file => "Build" };
+
+        unlink "Build";
+        App::cpm::Builder::MB->new(
+            distfile => "A-1.0.tar.gz",
+            install_base => "/tmp/local",
+            use_install_command => 0,
+            argv => [],
+        )->configure($ctx, [], []);
+        is_deeply \@cmd, [ $^X, "Build.PL" ];
+
+        unlink "Build";
+        App::cpm::Builder::MB->new(
+            distfile => "A-1.0.tar.gz",
+            install_base => "/tmp/local",
+            use_install_command => 1,
+            argv => [],
+        )->configure($ctx, [], []);
+        is_deeply \@cmd, [ $^X, "Build.PL", "--install_base", "/tmp/local" ];
+    };
+}
+
+done_testing;


### PR DESCRIPTION
## Summary
- disable prebuilt when --use-install-command is enabled
- only pass INSTALL_BASE / --install_base during configure when using install commands
- avoid adding absent local lib/bin paths to PERL5LIB/PATH during builder commands

## Tests
- prove -lr --jobs 4 t xt