### PR TITLE
Fix --reinstall for dependency files

### DIFF
--- a/lib/App/cpm/CLI.pm
+++ b/lib/App/cpm/CLI.pm
@@ -662,9 +662,9 @@ sub load_dependency_file ($self, $ctx) {
             package => $package,
             version_range => $options->{version},
             dev => $options->{dev},
-            reinstall => $options->{git} ? 1 : 0,
+            reinstall => $package ne "perl" && ($self->{reinstall} || $options->{git}) ? 1 : 0,
         };
-        if ($options->{git}) {
+        if ($req->{reinstall}) {
             push @reinstall, $req;
         } else {
             push @package, $req;

--- a/xt/23_same_module.t
+++ b/xt/23_same_module.t
@@ -75,6 +75,10 @@ with_same_local {
     $r = cpm_install "--cpanfile", $cpanfile;
     is $r->exit, 0;
     like $r->err, qr/All requirements are satisfied/;
+
+    $r = cpm_install "--cpanfile", $cpanfile, "--reinstall";
+    is $r->exit, 0;
+    like $r->log, qr/Parallel-Pipes-[^\|]+\| Successfully installed distribution/;
 };
 
 done_testing;


### PR DESCRIPTION
## Summary

- honor `--reinstall` for requirements loaded from dependency files such as `cpanfile` and `META.json`
- keep `perl` out of dependency-file reinstall targets
- add a regression test for `--cpanfile --reinstall`

Fixes #294.

## Tests

- `prove -l t xt`