### PR TITLE
Optimize runtime dependency readiness tracking

### DIFF
--- a/lib/App/cpm/DependencyIndex.pm
+++ b/lib/App/cpm/DependencyIndex.pm
@@ -1,0 +1,82 @@
+package App::cpm::DependencyIndex;
+use v5.24;
+use warnings;
+use experimental qw(signatures);
+
+sub new ($class) {
+    bless {
+        provided_by_package => +{},
+        runtime_waiting_by_distfile => +{},
+        runtime_waiting_by_package => +{},
+        runtime_dirty => +{},
+    }, $class;
+}
+
+sub index_provides ($self, $distribution, $provides) {
+    my $distfile = $distribution->distfile;
+    for my $provide ($provides->@*) {
+        my $package = $provide->{package};
+        my $candidates = $self->{provided_by_package}{$package} ||= [];
+        push $candidates->@*, $distribution
+            if !grep { $_->distfile eq $distfile } $candidates->@*;
+    }
+}
+
+sub providers_for ($self, $package) {
+    ($self->{provided_by_package}{$package} || [])->@*;
+}
+
+sub mark_distfile_ready ($self, $distfile) {
+    if (my $waiters = $self->{runtime_waiting_by_distfile}{$distfile}) {
+        $self->{runtime_dirty}{$_} = 1 for keys $waiters->%*;
+    }
+}
+
+sub mark_packages_resolved ($self, @package) {
+    for my $package (@package) {
+        if (my $waiters = $self->{runtime_waiting_by_package}{$package}) {
+            $self->{runtime_dirty}{$_} = 1 for keys $waiters->%*;
+        }
+    }
+}
+
+sub is_runtime_dirty ($self, $dist) {
+    $self->{runtime_dirty}{ $dist->distfile };
+}
+
+sub has_runtime_waiting ($self, $dist) {
+    $dist->{_runtime_waiting_distfiles} || $dist->{_runtime_waiting_packages};
+}
+
+sub clear_runtime_waiting ($self, $dist) {
+    my $distfile = $dist->distfile;
+    my $waiting_distfiles = $dist->{_runtime_waiting_distfiles} || {};
+    for my $wait_distfile (keys $waiting_distfiles->%*) {
+        delete $self->{runtime_waiting_by_distfile}{$wait_distfile}{$distfile};
+        delete $self->{runtime_waiting_by_distfile}{$wait_distfile}
+            if !keys $self->{runtime_waiting_by_distfile}{$wait_distfile}->%*;
+    }
+    my $waiting_packages = $dist->{_runtime_waiting_packages} || {};
+    for my $package (keys $waiting_packages->%*) {
+        delete $self->{runtime_waiting_by_package}{$package}{$distfile};
+        delete $self->{runtime_waiting_by_package}{$package}
+            if !keys $self->{runtime_waiting_by_package}{$package}->%*;
+    }
+    delete $dist->{_runtime_waiting_distfiles};
+    delete $dist->{_runtime_waiting_packages};
+    delete $self->{runtime_dirty}{$distfile};
+}
+
+sub remember_runtime_waiting ($self, $dist, $wait_distfile, $wait_package) {
+    my $distfile = $dist->distfile;
+    $self->clear_runtime_waiting($dist);
+
+    if ($wait_distfile->%* || $wait_package->%*) {
+        $dist->{_runtime_waiting_distfiles} = $wait_distfile;
+        $dist->{_runtime_waiting_packages} = $wait_package;
+        $self->{runtime_waiting_by_distfile}{$_}{$distfile} = 1 for keys $wait_distfile->%*;
+        $self->{runtime_waiting_by_package}{$_}{$distfile} = 1 for keys $wait_package->%*;
+    }
+}
+
+1;

--- a/lib/App/cpm/DependencyIndex.pm
+++ b/lib/App/cpm/DependencyIndex.pm
@@ -5,15 +5,29 @@ use experimental qw(lexical_subs signatures);
 
 sub new ($class) {
     bless {
+        dependency_ready => +{},
         provided_by_package => +{},
+        _resolved_distribution => +{},
         runtime_waiting_by_distfile => +{},
         runtime_waiting_by_package => +{},
         runtime_dirty => +{},
     }, $class;
 }
 
+sub dependency_ready ($self, $dist, @argv) {
+    my $distfile = $dist->distfile;
+    if (@argv) {
+        my $ready = $argv[0] ? 1 : 0;
+        my $was_ready = $self->{dependency_ready}{$distfile} || 0;
+        $self->{dependency_ready}{$distfile} = $ready;
+        $self->mark_distfile_ready($distfile) if !$was_ready && $ready;
+    }
+    $self->{dependency_ready}{$distfile};
+}
+
 sub index_provides ($self, $dist, $provides) {
     my $distfile = $dist->distfile;
+    delete $self->{_resolved_distribution};
     for my $provide ($provides->@*) {
         my $package = $provide->{package};
         my $candidates = $self->{provided_by_package}{$package} ||= [];
@@ -22,8 +36,14 @@ sub index_provides ($self, $dist, $provides) {
     }
 }
 
-sub providers_for ($self, $package) {
-    ($self->{provided_by_package}{$package} || [])->@*;
+sub resolved_distribution ($self, $package, $version_range = undef) {
+    my $key = join "\0", $package, $version_range // "";
+    return $self->{_resolved_distribution}{$key} if exists $self->{_resolved_distribution}{$key};
+
+    my $candidates = $self->{provided_by_package}{$package} || [];
+    my ($resolved) = grep { $_->providing($package, $version_range) } $candidates->@*;
+    $self->{_resolved_distribution}{$key} = $resolved;
+    $resolved;
 }
 
 sub mark_distfile_ready ($self, $distfile) {

--- a/lib/App/cpm/DependencyIndex.pm
+++ b/lib/App/cpm/DependencyIndex.pm
@@ -1,7 +1,7 @@
 package App::cpm::DependencyIndex;
 use v5.24;
 use warnings;
-use experimental qw(signatures);
+use experimental qw(lexical_subs signatures);
 
 sub new ($class) {
     bless {
@@ -12,12 +12,12 @@ sub new ($class) {
     }, $class;
 }
 
-sub index_provides ($self, $distribution, $provides) {
-    my $distfile = $distribution->distfile;
+sub index_provides ($self, $dist, $provides) {
+    my $distfile = $dist->distfile;
     for my $provide ($provides->@*) {
         my $package = $provide->{package};
         my $candidates = $self->{provided_by_package}{$package} ||= [];
-        push $candidates->@*, $distribution
+        push $candidates->@*, $dist
             if !grep { $_->distfile eq $distfile } $candidates->@*;
     }
 }

--- a/lib/App/cpm/DependencyTracker.pm
+++ b/lib/App/cpm/DependencyTracker.pm
@@ -3,6 +3,10 @@ use v5.24;
 use warnings;
 use experimental qw(lexical_subs signatures);
 
+# This class owns dependency state, indexes, and caches that make lookups cheap.
+# App::cpm::Master owns install scheduling decisions, including phase handling,
+# core/installed module checks, resolve task registration, and install failure handling.
+
 sub new ($class) {
     bless {
         dependency_ready_by_distfile => +{},

--- a/lib/App/cpm/DependencyTracker.pm
+++ b/lib/App/cpm/DependencyTracker.pm
@@ -12,6 +12,8 @@ sub new ($class) {
         dependency_ready_by_distfile => +{},
         provider_dists_by_package => +{},
         _resolved_distribution_by_requirement => +{},
+        runtime_dependency_waiting_distfiles_by_distfile => +{},
+        runtime_dependency_waiting_packages_by_distfile => +{},
         runtime_dependency_waiters_by_distfile => +{},
         runtime_dependency_waiters_by_package => +{},
         runtime_dependency_dirty_by_distfile => +{},
@@ -70,25 +72,27 @@ sub is_runtime_dependency_dirty ($self, $dist) {
 }
 
 sub has_runtime_dependency_waiting ($self, $dist) {
-    $dist->{_runtime_dependency_waiting_distfiles} || $dist->{_runtime_dependency_waiting_packages};
+    my $distfile = $dist->distfile;
+    $self->{runtime_dependency_waiting_distfiles_by_distfile}{$distfile}
+        || $self->{runtime_dependency_waiting_packages_by_distfile}{$distfile};
 }
 
 sub clear_runtime_dependency_waiting ($self, $dist) {
     my $distfile = $dist->distfile;
-    my $waiting_distfiles = $dist->{_runtime_dependency_waiting_distfiles} || {};
+    my $waiting_distfiles = $self->{runtime_dependency_waiting_distfiles_by_distfile}{$distfile} || {};
     for my $waiting_distfile (keys $waiting_distfiles->%*) {
         delete $self->{runtime_dependency_waiters_by_distfile}{$waiting_distfile}{$distfile};
         delete $self->{runtime_dependency_waiters_by_distfile}{$waiting_distfile}
             if !keys $self->{runtime_dependency_waiters_by_distfile}{$waiting_distfile}->%*;
     }
-    my $waiting_packages = $dist->{_runtime_dependency_waiting_packages} || {};
+    my $waiting_packages = $self->{runtime_dependency_waiting_packages_by_distfile}{$distfile} || {};
     for my $package (keys $waiting_packages->%*) {
         delete $self->{runtime_dependency_waiters_by_package}{$package}{$distfile};
         delete $self->{runtime_dependency_waiters_by_package}{$package}
             if !keys $self->{runtime_dependency_waiters_by_package}{$package}->%*;
     }
-    delete $dist->{_runtime_dependency_waiting_distfiles};
-    delete $dist->{_runtime_dependency_waiting_packages};
+    delete $self->{runtime_dependency_waiting_distfiles_by_distfile}{$distfile};
+    delete $self->{runtime_dependency_waiting_packages_by_distfile}{$distfile};
     delete $self->{runtime_dependency_dirty_by_distfile}{$distfile};
 }
 
@@ -97,8 +101,8 @@ sub remember_runtime_dependency_waiting ($self, $dist, $waiting_distfiles, $wait
     $self->clear_runtime_dependency_waiting($dist);
 
     if ($waiting_distfiles->%* || $waiting_packages->%*) {
-        $dist->{_runtime_dependency_waiting_distfiles} = $waiting_distfiles;
-        $dist->{_runtime_dependency_waiting_packages} = $waiting_packages;
+        $self->{runtime_dependency_waiting_distfiles_by_distfile}{$distfile} = $waiting_distfiles;
+        $self->{runtime_dependency_waiting_packages_by_distfile}{$distfile} = $waiting_packages;
         $self->{runtime_dependency_waiters_by_distfile}{$_}{$distfile} = 1 for keys $waiting_distfiles->%*;
         $self->{runtime_dependency_waiters_by_package}{$_}{$distfile} = 1 for keys $waiting_packages->%*;
     }

--- a/lib/App/cpm/DependencyTracker.pm
+++ b/lib/App/cpm/DependencyTracker.pm
@@ -1,4 +1,4 @@
-package App::cpm::DependencyIndex;
+package App::cpm::DependencyTracker;
 use v5.24;
 use warnings;
 use experimental qw(lexical_subs signatures);

--- a/lib/App/cpm/DependencyTracker.pm
+++ b/lib/App/cpm/DependencyTracker.pm
@@ -25,7 +25,7 @@ sub dependency_ready ($self, $dist, @argv) {
     $self->{dependency_ready}{$distfile};
 }
 
-sub index_provides ($self, $dist, $provides) {
+sub add_provides ($self, $dist, $provides) {
     my $distfile = $dist->distfile;
     delete $self->{_resolved_distribution};
     for my $provide ($provides->@*) {

--- a/lib/App/cpm/DependencyTracker.pm
+++ b/lib/App/cpm/DependencyTracker.pm
@@ -29,7 +29,9 @@ sub mark_dependency_ready ($self, $dist) {
     my $distfile = $dist->distfile;
     my $was_ready = $self->{dependency_ready_by_distfile}{$distfile} || 0;
     $self->{dependency_ready_by_distfile}{$distfile} = 1;
-    $self->_mark_dependency_ready_distfile($distfile) if !$was_ready;
+    if (!$was_ready && (my $waiters = $self->{runtime_dependency_waiters_by_distfile}{$distfile})) {
+        $self->{runtime_dependency_dirty_by_distfile}{$_} = 1 for keys $waiters->%*;
+    }
 }
 
 sub add_provides ($self, $dist, $provides) {
@@ -54,12 +56,6 @@ sub resolved_distribution ($self, $package, $version_range = undef) {
     my ($resolved) = grep { $_->providing($package, $version_range) } $provider_dists->@*;
     $self->{resolved_distribution_by_requirement}{$key} = $resolved;
     $resolved;
-}
-
-sub _mark_dependency_ready_distfile ($self, $distfile) {
-    if (my $waiters = $self->{runtime_dependency_waiters_by_distfile}{$distfile}) {
-        $self->{runtime_dependency_dirty_by_distfile}{$_} = 1 for keys $waiters->%*;
-    }
 }
 
 sub is_runtime_dependency_dirty ($self, $dist) {

--- a/lib/App/cpm/DependencyTracker.pm
+++ b/lib/App/cpm/DependencyTracker.pm
@@ -5,97 +5,98 @@ use experimental qw(lexical_subs signatures);
 
 sub new ($class) {
     bless {
-        dependency_ready => +{},
-        provided_by_package => +{},
-        _resolved_distribution => +{},
-        runtime_waiting_by_distfile => +{},
-        runtime_waiting_by_package => +{},
-        runtime_dirty => +{},
+        dependency_ready_by_distfile => +{},
+        provider_dists_by_package => +{},
+        _resolved_distribution_by_requirement => +{},
+        runtime_dependency_waiters_by_distfile => +{},
+        runtime_dependency_waiters_by_package => +{},
+        runtime_dependency_dirty_by_distfile => +{},
     }, $class;
 }
 
-sub dependency_ready ($self, $dist, @argv) {
+sub is_dependency_ready ($self, $dist) {
     my $distfile = $dist->distfile;
-    if (@argv) {
-        my $ready = $argv[0] ? 1 : 0;
-        my $was_ready = $self->{dependency_ready}{$distfile} || 0;
-        $self->{dependency_ready}{$distfile} = $ready;
-        $self->mark_distfile_ready($distfile) if !$was_ready && $ready;
-    }
-    $self->{dependency_ready}{$distfile};
+    $self->{dependency_ready_by_distfile}{$distfile};
+}
+
+sub mark_dependency_ready ($self, $dist) {
+    my $distfile = $dist->distfile;
+    my $was_ready = $self->{dependency_ready_by_distfile}{$distfile} || 0;
+    $self->{dependency_ready_by_distfile}{$distfile} = 1;
+    $self->_mark_dependency_ready_distfile($distfile) if !$was_ready;
 }
 
 sub add_provides ($self, $dist, $provides) {
     my $distfile = $dist->distfile;
-    delete $self->{_resolved_distribution};
+    delete $self->{_resolved_distribution_by_requirement};
     for my $provide ($provides->@*) {
         my $package = $provide->{package};
-        my $candidates = $self->{provided_by_package}{$package} ||= [];
-        push $candidates->@*, $dist
-            if !grep { $_->distfile eq $distfile } $candidates->@*;
+        my $provider_dists = $self->{provider_dists_by_package}{$package} ||= [];
+        push $provider_dists->@*, $dist
+            if !grep { $_->distfile eq $distfile } $provider_dists->@*;
     }
 }
 
 sub resolved_distribution ($self, $package, $version_range = undef) {
     my $key = join "\0", $package, $version_range // "";
-    return $self->{_resolved_distribution}{$key} if exists $self->{_resolved_distribution}{$key};
+    return $self->{_resolved_distribution_by_requirement}{$key} if exists $self->{_resolved_distribution_by_requirement}{$key};
 
-    my $candidates = $self->{provided_by_package}{$package} || [];
-    my ($resolved) = grep { $_->providing($package, $version_range) } $candidates->@*;
-    $self->{_resolved_distribution}{$key} = $resolved;
+    my $provider_dists = $self->{provider_dists_by_package}{$package} || [];
+    my ($resolved) = grep { $_->providing($package, $version_range) } $provider_dists->@*;
+    $self->{_resolved_distribution_by_requirement}{$key} = $resolved;
     $resolved;
 }
 
-sub mark_distfile_ready ($self, $distfile) {
-    if (my $waiters = $self->{runtime_waiting_by_distfile}{$distfile}) {
-        $self->{runtime_dirty}{$_} = 1 for keys $waiters->%*;
+sub _mark_dependency_ready_distfile ($self, $distfile) {
+    if (my $waiters = $self->{runtime_dependency_waiters_by_distfile}{$distfile}) {
+        $self->{runtime_dependency_dirty_by_distfile}{$_} = 1 for keys $waiters->%*;
     }
 }
 
-sub mark_packages_resolved ($self, @package) {
-    for my $package (@package) {
-        if (my $waiters = $self->{runtime_waiting_by_package}{$package}) {
-            $self->{runtime_dirty}{$_} = 1 for keys $waiters->%*;
+sub mark_resolved_packages ($self, @packages) {
+    for my $package (@packages) {
+        if (my $waiters = $self->{runtime_dependency_waiters_by_package}{$package}) {
+            $self->{runtime_dependency_dirty_by_distfile}{$_} = 1 for keys $waiters->%*;
         }
     }
 }
 
-sub is_runtime_dirty ($self, $dist) {
-    $self->{runtime_dirty}{ $dist->distfile };
+sub is_runtime_dependency_dirty ($self, $dist) {
+    $self->{runtime_dependency_dirty_by_distfile}{ $dist->distfile };
 }
 
-sub has_runtime_waiting ($self, $dist) {
-    $dist->{_runtime_waiting_distfiles} || $dist->{_runtime_waiting_packages};
+sub has_runtime_dependency_waiting ($self, $dist) {
+    $dist->{_runtime_dependency_waiting_distfiles} || $dist->{_runtime_dependency_waiting_packages};
 }
 
-sub clear_runtime_waiting ($self, $dist) {
+sub clear_runtime_dependency_waiting ($self, $dist) {
     my $distfile = $dist->distfile;
-    my $waiting_distfiles = $dist->{_runtime_waiting_distfiles} || {};
-    for my $wait_distfile (keys $waiting_distfiles->%*) {
-        delete $self->{runtime_waiting_by_distfile}{$wait_distfile}{$distfile};
-        delete $self->{runtime_waiting_by_distfile}{$wait_distfile}
-            if !keys $self->{runtime_waiting_by_distfile}{$wait_distfile}->%*;
+    my $waiting_distfiles = $dist->{_runtime_dependency_waiting_distfiles} || {};
+    for my $waiting_distfile (keys $waiting_distfiles->%*) {
+        delete $self->{runtime_dependency_waiters_by_distfile}{$waiting_distfile}{$distfile};
+        delete $self->{runtime_dependency_waiters_by_distfile}{$waiting_distfile}
+            if !keys $self->{runtime_dependency_waiters_by_distfile}{$waiting_distfile}->%*;
     }
-    my $waiting_packages = $dist->{_runtime_waiting_packages} || {};
+    my $waiting_packages = $dist->{_runtime_dependency_waiting_packages} || {};
     for my $package (keys $waiting_packages->%*) {
-        delete $self->{runtime_waiting_by_package}{$package}{$distfile};
-        delete $self->{runtime_waiting_by_package}{$package}
-            if !keys $self->{runtime_waiting_by_package}{$package}->%*;
+        delete $self->{runtime_dependency_waiters_by_package}{$package}{$distfile};
+        delete $self->{runtime_dependency_waiters_by_package}{$package}
+            if !keys $self->{runtime_dependency_waiters_by_package}{$package}->%*;
     }
-    delete $dist->{_runtime_waiting_distfiles};
-    delete $dist->{_runtime_waiting_packages};
-    delete $self->{runtime_dirty}{$distfile};
+    delete $dist->{_runtime_dependency_waiting_distfiles};
+    delete $dist->{_runtime_dependency_waiting_packages};
+    delete $self->{runtime_dependency_dirty_by_distfile}{$distfile};
 }
 
-sub remember_runtime_waiting ($self, $dist, $wait_distfile, $wait_package) {
+sub remember_runtime_dependency_waiting ($self, $dist, $waiting_distfiles, $waiting_packages) {
     my $distfile = $dist->distfile;
-    $self->clear_runtime_waiting($dist);
+    $self->clear_runtime_dependency_waiting($dist);
 
-    if ($wait_distfile->%* || $wait_package->%*) {
-        $dist->{_runtime_waiting_distfiles} = $wait_distfile;
-        $dist->{_runtime_waiting_packages} = $wait_package;
-        $self->{runtime_waiting_by_distfile}{$_}{$distfile} = 1 for keys $wait_distfile->%*;
-        $self->{runtime_waiting_by_package}{$_}{$distfile} = 1 for keys $wait_package->%*;
+    if ($waiting_distfiles->%* || $waiting_packages->%*) {
+        $dist->{_runtime_dependency_waiting_distfiles} = $waiting_distfiles;
+        $dist->{_runtime_dependency_waiting_packages} = $waiting_packages;
+        $self->{runtime_dependency_waiters_by_distfile}{$_}{$distfile} = 1 for keys $waiting_distfiles->%*;
+        $self->{runtime_dependency_waiters_by_package}{$_}{$distfile} = 1 for keys $waiting_packages->%*;
     }
 }
 

--- a/lib/App/cpm/DependencyTracker.pm
+++ b/lib/App/cpm/DependencyTracker.pm
@@ -40,6 +40,9 @@ sub add_provides ($self, $dist, $provides) {
         my $provider_dists = $self->{provider_dists_by_package}{$package} ||= [];
         push $provider_dists->@*, $dist
             if !grep { $_->distfile eq $distfile } $provider_dists->@*;
+        if (my $waiters = $self->{runtime_dependency_waiters_by_package}{$package}) {
+            $self->{runtime_dependency_dirty_by_distfile}{$_} = 1 for keys $waiters->%*;
+        }
     }
 }
 
@@ -56,14 +59,6 @@ sub resolved_distribution ($self, $package, $version_range = undef) {
 sub _mark_dependency_ready_distfile ($self, $distfile) {
     if (my $waiters = $self->{runtime_dependency_waiters_by_distfile}{$distfile}) {
         $self->{runtime_dependency_dirty_by_distfile}{$_} = 1 for keys $waiters->%*;
-    }
-}
-
-sub mark_resolved_packages ($self, @packages) {
-    for my $package (@packages) {
-        if (my $waiters = $self->{runtime_dependency_waiters_by_package}{$package}) {
-            $self->{runtime_dependency_dirty_by_distfile}{$_} = 1 for keys $waiters->%*;
-        }
     }
 }
 

--- a/lib/App/cpm/DependencyTracker.pm
+++ b/lib/App/cpm/DependencyTracker.pm
@@ -11,7 +11,7 @@ sub new ($class) {
     bless {
         dependency_ready_by_distfile => +{},
         provider_dists_by_package => +{},
-        _resolved_distribution_by_requirement => +{},
+        resolved_distribution_by_requirement => +{},
         runtime_dependency_waiting_distfiles_by_distfile => +{},
         runtime_dependency_waiting_packages_by_distfile => +{},
         runtime_dependency_waiters_by_distfile => +{},
@@ -34,7 +34,7 @@ sub mark_dependency_ready ($self, $dist) {
 
 sub add_provides ($self, $dist, $provides) {
     my $distfile = $dist->distfile;
-    delete $self->{_resolved_distribution_by_requirement};
+    delete $self->{resolved_distribution_by_requirement};
     for my $provide ($provides->@*) {
         my $package = $provide->{package};
         my $provider_dists = $self->{provider_dists_by_package}{$package} ||= [];
@@ -45,11 +45,11 @@ sub add_provides ($self, $dist, $provides) {
 
 sub resolved_distribution ($self, $package, $version_range = undef) {
     my $key = join "\0", $package, $version_range // "";
-    return $self->{_resolved_distribution_by_requirement}{$key} if exists $self->{_resolved_distribution_by_requirement}{$key};
+    return $self->{resolved_distribution_by_requirement}{$key} if exists $self->{resolved_distribution_by_requirement}{$key};
 
     my $provider_dists = $self->{provider_dists_by_package}{$package} || [];
     my ($resolved) = grep { $_->providing($package, $version_range) } $provider_dists->@*;
-    $self->{_resolved_distribution_by_requirement}{$key} = $resolved;
+    $self->{resolved_distribution_by_requirement}{$key} = $resolved;
     $resolved;
 }
 

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -4,7 +4,7 @@ use warnings;
 use experimental qw(lexical_subs signatures);
 
 use App::cpm::CircularDependency;
-use App::cpm::DependencyIndex;
+use App::cpm::DependencyTracker;
 use App::cpm::Distribution;
 use App::cpm::Logger;
 use App::cpm::Logger::Terminal;
@@ -20,7 +20,7 @@ sub new ($class, %argv) {
         installed_distributions => 0,
         tasks => +{},
         distributions => +{},
-        dependency_index => App::cpm::DependencyIndex->new,
+        dependency_tracker => App::cpm::DependencyTracker->new,
         _fail_resolve => +{},
         _fail_install => +{},
         _is_installed => +{},
@@ -217,12 +217,12 @@ sub dependency_env_for ($self, $dist, $phases, $seen = undef, $found = undef) {
         next if $package eq "perl";
         next if $self->{target_perl} and $self->is_core($package, $version_range);
 
-        my $resolved = $self->{dependency_index}->resolved_distribution($package, $version_range);
+        my $resolved = $self->{dependency_tracker}->resolved_distribution($package, $version_range);
         if (!$resolved) {
             next if $self->is_installed($package, $version_range);
             next;
         }
-        next if !$self->{dependency_index}->dependency_ready($resolved);
+        next if !$self->{dependency_tracker}->dependency_ready($resolved);
         next if $seen->{$resolved->distfile}++;
 
         $found->{$resolved->distfile} = $resolved;
@@ -242,7 +242,7 @@ sub dependency_env_for ($self, $dist, $phases, $seen = undef, $found = undef) {
 }
 
 sub _final_install_distributions ($self, $include_unready = 0) {
-    return grep { $include_unready || $self->{dependency_index}->dependency_ready($_) } $self->distributions
+    return grep { $include_unready || $self->{dependency_tracker}->dependency_ready($_) } $self->distributions
         if $self->{final_install} eq "all";
 
     my %seen;
@@ -250,14 +250,14 @@ sub _final_install_distributions ($self, $include_unready = 0) {
     my @install;
     while (my $dist = shift @todo) {
         next if $seen{$dist->distfile}++;
-        push @install, $dist if $include_unready || $self->{dependency_index}->dependency_ready($dist);
+        push @install, $dist if $include_unready || $self->{dependency_tracker}->dependency_ready($dist);
 
         for my $req ($dist->requirements('runtime')->as_array->@*) {
             my ($package, $version_range) = $req->@{qw(package version_range)};
             next if $package eq "perl";
             next if $self->{target_perl} and $self->is_core($package, $version_range);
 
-            my $resolved = $self->{dependency_index}->resolved_distribution($package, $version_range);
+            my $resolved = $self->{dependency_tracker}->resolved_distribution($package, $version_range);
             next if !$resolved;
             next if $self->is_installed($package, $version_range);
             push @todo, $resolved;
@@ -333,20 +333,20 @@ sub _add_tasks ($self, $ctx) {
 sub _mark_built_dependency_ready ($self, $ctx) {
     my $changed = 0;
     my @distributions = grep { !$self->{_fail_install}{$_->distfile} } $self->distributions;
-    if (my @dists = grep { $_->built && !$self->{dependency_index}->dependency_ready($_) } @distributions) {
+    if (my @dists = grep { $_->built && !$self->{dependency_tracker}->dependency_ready($_) } @distributions) {
         for my $dist (@dists) {
-            my $dependency_index = $self->{dependency_index};
-            if ($dependency_index->has_runtime_waiting($dist) && !$dependency_index->is_runtime_dirty($dist)) {
+            my $dependency_tracker = $self->{dependency_tracker};
+            if ($dependency_tracker->has_runtime_waiting($dist) && !$dependency_tracker->is_runtime_dirty($dist)) {
                 next;
             }
             my $dist_requirements = $dist->requirements('runtime')->as_array;
             my ($is_satisfied, @need_resolve) = $self->is_satisfied($dist_requirements);
             if ($is_satisfied) {
-                $dependency_index->clear_runtime_waiting($dist);
-                $self->{dependency_index}->dependency_ready($dist, 1);
+                $dependency_tracker->clear_runtime_waiting($dist);
+                $self->{dependency_tracker}->dependency_ready($dist, 1);
                 $changed++;
             } elsif (!defined $is_satisfied) {
-                $dependency_index->clear_runtime_waiting($dist);
+                $dependency_tracker->clear_runtime_waiting($dist);
                 local $ctx->{logger}{context} = $dist->distvname;
                 my ($req) = grep { $_->{package} eq "perl" } $dist_requirements->@*;
                 my $msg = sprintf "%s requires perl %s, but you have only %s",
@@ -363,10 +363,10 @@ sub _mark_built_dependency_ready ($self, $ctx) {
                 $ctx->log($msg);
                 my $ok = $self->_register_resolve_task($ctx, @need_resolve);
                 $self->{_fail_install}{$dist->distfile}++ if !$ok;
-                $dependency_index->remember_runtime_waiting($dist, $self->_runtime_waiting_for($dist_requirements));
+                $dependency_tracker->remember_runtime_waiting($dist, $self->_runtime_waiting_for($dist_requirements));
                 $changed++;
             } else {
-                $dependency_index->remember_runtime_waiting($dist, $self->_runtime_waiting_for($dist_requirements));
+                $dependency_tracker->remember_runtime_waiting($dist, $self->_runtime_waiting_for($dist_requirements));
             }
         }
     }
@@ -380,9 +380,9 @@ sub _runtime_waiting_for ($self, $requirements) {
         next if $package eq "perl";
         next if $self->{target_perl} and $self->is_core($package, $version_range);
 
-        my $resolved = $self->{dependency_index}->resolved_distribution($package, $version_range);
+        my $resolved = $self->{dependency_tracker}->resolved_distribution($package, $version_range);
         if ($resolved) {
-            next if $self->{dependency_index}->dependency_ready($resolved);
+            next if $self->{dependency_tracker}->dependency_ready($resolved);
             $wait_distfile{$resolved->distfile} = 1;
         } else {
             next if $self->is_installed($package, $version_range);
@@ -394,8 +394,8 @@ sub _runtime_waiting_for ($self, $requirements) {
 
 sub _mark_tested_dependency_ready ($self, $ctx) {
     my @distributions = grep { !$self->{_fail_install}{$_->distfile} } $self->distributions;
-    my @dists = grep { $_->tested && !$self->{dependency_index}->dependency_ready($_) } @distributions;
-    $self->{dependency_index}->dependency_ready($_, 1) for @dists;
+    my @dists = grep { $_->tested && !$self->{dependency_tracker}->dependency_ready($_) } @distributions;
+    $self->{dependency_tracker}->dependency_ready($_, 1) for @dists;
     return scalar @dists;
 }
 
@@ -643,9 +643,9 @@ sub is_satisfied ($self, $requirements) {
             next;
         }
         next if $self->{target_perl} and $self->is_core($package, $version_range);
-        my $resolved = $self->{dependency_index}->resolved_distribution($package, $version_range);
+        my $resolved = $self->{dependency_tracker}->resolved_distribution($package, $version_range);
         if ($resolved) {
-            next if $self->{dependency_index}->dependency_ready($resolved);
+            next if $self->{dependency_tracker}->dependency_ready($resolved);
         } else {
             next if $self->is_installed($package, $version_range);
         }
@@ -661,16 +661,16 @@ sub is_satisfied ($self, $requirements) {
 sub add_distribution ($self, $distribution) {
     my $distfile = $distribution->distfile;
     if (my $already = $self->{distributions}{$distfile}) {
-        $self->{dependency_index}->index_provides($already, $distribution->provides);
-        $self->{dependency_index}->mark_packages_resolved(map { $_->{package} } $distribution->provides->@*);
+        $self->{dependency_tracker}->index_provides($already, $distribution->provides);
+        $self->{dependency_tracker}->mark_packages_resolved(map { $_->{package} } $distribution->provides->@*);
         if ($already->resolved) {
             $already->overwrite_provide($_) for $distribution->provides->@*;
         }
         return 0;
     } else {
         $self->{distributions}{$distfile} = $distribution;
-        $self->{dependency_index}->index_provides($distribution, $distribution->provides);
-        $self->{dependency_index}->mark_packages_resolved(map { $_->{package} } $distribution->provides->@*);
+        $self->{dependency_tracker}->index_provides($distribution, $distribution->provides);
+        $self->{dependency_tracker}->mark_packages_resolved(map { $_->{package} } $distribution->provides->@*);
         return 1;
     }
 }

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -208,33 +208,6 @@ sub install_phase_state ($self, $dist) {
     return $self->{notest} ? "built" : "tested";
 }
 
-sub dependency_ready ($self, $dist, @argv) {
-    $self->{dependency_index}->dependency_ready($dist, @argv);
-}
-
-sub _runtime_waiting_for ($self, $requirements) {
-    my (%wait_distfile, %wait_package);
-    for my $req ($requirements->@*) {
-        my ($package, $version_range) = $req->@{qw(package version_range)};
-        next if $package eq "perl";
-        next if $self->{target_perl} and $self->is_core($package, $version_range);
-
-        my $resolved = $self->_resolved_distribution($package, $version_range);
-        if ($resolved) {
-            next if $self->dependency_ready($resolved);
-            $wait_distfile{$resolved->distfile} = 1;
-        } else {
-            next if $self->is_installed($package, $version_range);
-            $wait_package{$package} = 1;
-        }
-    }
-    (\%wait_distfile, \%wait_package);
-}
-
-sub _resolved_distribution ($self, $package, $version_range = undef) {
-    $self->{dependency_index}->resolved_distribution($package, $version_range);
-}
-
 sub dependency_env_for ($self, $dist, $phases, $seen = undef, $found = undef) {
     $seen ||= {};
     $found ||= {};
@@ -244,12 +217,12 @@ sub dependency_env_for ($self, $dist, $phases, $seen = undef, $found = undef) {
         next if $package eq "perl";
         next if $self->{target_perl} and $self->is_core($package, $version_range);
 
-        my $resolved = $self->_resolved_distribution($package, $version_range);
+        my $resolved = $self->{dependency_index}->resolved_distribution($package, $version_range);
         if (!$resolved) {
             next if $self->is_installed($package, $version_range);
             next;
         }
-        next if !$self->dependency_ready($resolved);
+        next if !$self->{dependency_index}->dependency_ready($resolved);
         next if $seen->{$resolved->distfile}++;
 
         $found->{$resolved->distfile} = $resolved;
@@ -269,7 +242,7 @@ sub dependency_env_for ($self, $dist, $phases, $seen = undef, $found = undef) {
 }
 
 sub _final_install_distributions ($self, $include_unready = 0) {
-    return grep { $include_unready || $self->dependency_ready($_) } $self->distributions
+    return grep { $include_unready || $self->{dependency_index}->dependency_ready($_) } $self->distributions
         if $self->{final_install} eq "all";
 
     my %seen;
@@ -277,14 +250,14 @@ sub _final_install_distributions ($self, $include_unready = 0) {
     my @install;
     while (my $dist = shift @todo) {
         next if $seen{$dist->distfile}++;
-        push @install, $dist if $include_unready || $self->dependency_ready($dist);
+        push @install, $dist if $include_unready || $self->{dependency_index}->dependency_ready($dist);
 
         for my $req ($dist->requirements('runtime')->as_array->@*) {
             my ($package, $version_range) = $req->@{qw(package version_range)};
             next if $package eq "perl";
             next if $self->{target_perl} and $self->is_core($package, $version_range);
 
-            my $resolved = $self->_resolved_distribution($package, $version_range);
+            my $resolved = $self->{dependency_index}->resolved_distribution($package, $version_range);
             next if !$resolved;
             next if $self->is_installed($package, $version_range);
             push @todo, $resolved;
@@ -360,7 +333,7 @@ sub _add_tasks ($self, $ctx) {
 sub _mark_built_dependency_ready ($self, $ctx) {
     my $changed = 0;
     my @distributions = grep { !$self->{_fail_install}{$_->distfile} } $self->distributions;
-    if (my @dists = grep { $_->built && !$self->dependency_ready($_) } @distributions) {
+    if (my @dists = grep { $_->built && !$self->{dependency_index}->dependency_ready($_) } @distributions) {
         for my $dist (@dists) {
             my $dependency_index = $self->{dependency_index};
             if ($dependency_index->has_runtime_waiting($dist) && !$dependency_index->is_runtime_dirty($dist)) {
@@ -370,7 +343,7 @@ sub _mark_built_dependency_ready ($self, $ctx) {
             my ($is_satisfied, @need_resolve) = $self->is_satisfied($dist_requirements);
             if ($is_satisfied) {
                 $dependency_index->clear_runtime_waiting($dist);
-                $self->dependency_ready($dist, 1);
+                $self->{dependency_index}->dependency_ready($dist, 1);
                 $changed++;
             } elsif (!defined $is_satisfied) {
                 $dependency_index->clear_runtime_waiting($dist);
@@ -400,10 +373,29 @@ sub _mark_built_dependency_ready ($self, $ctx) {
     return $changed;
 }
 
+sub _runtime_waiting_for ($self, $requirements) {
+    my (%wait_distfile, %wait_package);
+    for my $req ($requirements->@*) {
+        my ($package, $version_range) = $req->@{qw(package version_range)};
+        next if $package eq "perl";
+        next if $self->{target_perl} and $self->is_core($package, $version_range);
+
+        my $resolved = $self->{dependency_index}->resolved_distribution($package, $version_range);
+        if ($resolved) {
+            next if $self->{dependency_index}->dependency_ready($resolved);
+            $wait_distfile{$resolved->distfile} = 1;
+        } else {
+            next if $self->is_installed($package, $version_range);
+            $wait_package{$package} = 1;
+        }
+    }
+    (\%wait_distfile, \%wait_package);
+}
+
 sub _mark_tested_dependency_ready ($self, $ctx) {
     my @distributions = grep { !$self->{_fail_install}{$_->distfile} } $self->distributions;
-    my @dists = grep { $_->tested && !$self->dependency_ready($_) } @distributions;
-    $self->dependency_ready($_, 1) for @dists;
+    my @dists = grep { $_->tested && !$self->{dependency_index}->dependency_ready($_) } @distributions;
+    $self->{dependency_index}->dependency_ready($_, 1) for @dists;
     return scalar @dists;
 }
 
@@ -651,9 +643,9 @@ sub is_satisfied ($self, $requirements) {
             next;
         }
         next if $self->{target_perl} and $self->is_core($package, $version_range);
-        my $resolved = $self->_resolved_distribution($package, $version_range);
+        my $resolved = $self->{dependency_index}->resolved_distribution($package, $version_range);
         if ($resolved) {
-            next if $self->dependency_ready($resolved);
+            next if $self->{dependency_index}->dependency_ready($resolved);
         } else {
             next if $self->is_installed($package, $version_range);
         }

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -662,7 +662,6 @@ sub add_distribution ($self, $distribution) {
     my $distfile = $distribution->distfile;
     if (my $already = $self->{distributions}{$distfile}) {
         $self->{dependency_tracker}->add_provides($already, $distribution->provides);
-        $self->{dependency_tracker}->mark_resolved_packages(map { $_->{package} } $distribution->provides->@*);
         if ($already->resolved) {
             $already->overwrite_provide($_) for $distribution->provides->@*;
         }
@@ -670,7 +669,6 @@ sub add_distribution ($self, $distribution) {
     } else {
         $self->{distributions}{$distfile} = $distribution;
         $self->{dependency_tracker}->add_provides($distribution, $distribution->provides);
-        $self->{dependency_tracker}->mark_resolved_packages(map { $_->{package} } $distribution->provides->@*);
         return 1;
     }
 }
@@ -739,6 +737,7 @@ sub _register_fetch_result ($self, $ctx, $task) {
     $distribution->directory($task->{directory});
     $distribution->meta($task->{meta});
     $distribution->provides($task->{provides});
+    $self->{dependency_tracker}->add_provides($distribution, $distribution->provides);
 
     if ($task->{prebuilt}) {
         $distribution->built(1);

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -4,6 +4,7 @@ use warnings;
 use experimental qw(lexical_subs signatures);
 
 use App::cpm::CircularDependency;
+use App::cpm::DependencyIndex;
 use App::cpm::Distribution;
 use App::cpm::Logger;
 use App::cpm::Logger::Terminal;
@@ -19,11 +20,8 @@ sub new ($class, %argv) {
         installed_distributions => 0,
         tasks => +{},
         distributions => +{},
-        provided_by_package => +{},
         dependency_ready => +{},
-        runtime_waiting_by_distfile => +{},
-        runtime_waiting_by_package => +{},
-        runtime_dirty => +{},
+        dependency_index => App::cpm::DependencyIndex->new,
         _fail_resolve => +{},
         _fail_install => +{},
         _is_installed => +{},
@@ -217,48 +215,12 @@ sub dependency_ready ($self, $dist, @argv) {
         my $ready = $argv[0] ? 1 : 0;
         my $was_ready = $self->{dependency_ready}{$distfile} || 0;
         $self->{dependency_ready}{$distfile} = $ready;
-        $self->_mark_runtime_waiters_dirty($distfile) if !$was_ready && $ready;
+        $self->{dependency_index}->mark_distfile_ready($distfile) if !$was_ready && $ready;
     }
     $self->{dependency_ready}{$distfile};
 }
 
-sub _mark_runtime_waiters_dirty ($self, $distfile) {
-    if (my $waiters = $self->{runtime_waiting_by_distfile}{$distfile}) {
-        $self->{runtime_dirty}{$_} = 1 for keys $waiters->%*;
-    }
-}
-
-sub _mark_runtime_package_waiters_dirty ($self, @package) {
-    for my $package (@package) {
-        if (my $waiters = $self->{runtime_waiting_by_package}{$package}) {
-            $self->{runtime_dirty}{$_} = 1 for keys $waiters->%*;
-        }
-    }
-}
-
-sub _clear_runtime_waiting ($self, $dist) {
-    my $distfile = $dist->distfile;
-    my $waiting_distfiles = $dist->{_runtime_waiting_distfiles} || {};
-    for my $wait_distfile (keys $waiting_distfiles->%*) {
-        delete $self->{runtime_waiting_by_distfile}{$wait_distfile}{$distfile};
-        delete $self->{runtime_waiting_by_distfile}{$wait_distfile}
-            if !keys $self->{runtime_waiting_by_distfile}{$wait_distfile}->%*;
-    }
-    my $waiting_packages = $dist->{_runtime_waiting_packages} || {};
-    for my $package (keys $waiting_packages->%*) {
-        delete $self->{runtime_waiting_by_package}{$package}{$distfile};
-        delete $self->{runtime_waiting_by_package}{$package}
-            if !keys $self->{runtime_waiting_by_package}{$package}->%*;
-    }
-    delete $dist->{_runtime_waiting_distfiles};
-    delete $dist->{_runtime_waiting_packages};
-    delete $self->{runtime_dirty}{$distfile};
-}
-
-sub _remember_runtime_waiting ($self, $dist, $requirements) {
-    my $distfile = $dist->distfile;
-    $self->_clear_runtime_waiting($dist);
-
+sub _runtime_waiting_for ($self, $requirements) {
     my (%wait_distfile, %wait_package);
     for my $req ($requirements->@*) {
         my ($package, $version_range) = $req->@{qw(package version_range)};
@@ -274,33 +236,17 @@ sub _remember_runtime_waiting ($self, $dist, $requirements) {
             $wait_package{$package} = 1;
         }
     }
-
-    if (%wait_distfile || %wait_package) {
-        $dist->{_runtime_waiting_distfiles} = \%wait_distfile;
-        $dist->{_runtime_waiting_packages} = \%wait_package;
-        $self->{runtime_waiting_by_distfile}{$_}{$distfile} = 1 for keys %wait_distfile;
-        $self->{runtime_waiting_by_package}{$_}{$distfile} = 1 for keys %wait_package;
-    }
+    (\%wait_distfile, \%wait_package);
 }
 
 sub _resolved_distribution ($self, $package, $version_range = undef) {
     my $key = join "\0", $package, $version_range // "";
     return $self->{_resolved_distribution}{$key} if exists $self->{_resolved_distribution}{$key};
 
-    my $candidates = $self->{provided_by_package}{$package} || [];
-    my ($resolved) = grep { $_->providing($package, $version_range) } $candidates->@*;
+    my ($resolved) = grep { $_->providing($package, $version_range) }
+        $self->{dependency_index}->providers_for($package);
     $self->{_resolved_distribution}{$key} = $resolved;
     $resolved;
-}
-
-sub _index_provides ($self, $distribution, $provides) {
-    my $distfile = $distribution->distfile;
-    for my $provide ($provides->@*) {
-        my $package = $provide->{package};
-        my $candidates = $self->{provided_by_package}{$package} ||= [];
-        push $candidates->@*, $distribution
-            if !grep { $_->distfile eq $distfile } $candidates->@*;
-    }
 }
 
 sub dependency_env_for ($self, $dist, $phases, $seen = undef, $found = undef) {
@@ -430,18 +376,18 @@ sub _mark_built_dependency_ready ($self, $ctx) {
     my @distributions = grep { !$self->{_fail_install}{$_->distfile} } $self->distributions;
     if (my @dists = grep { $_->built && !$self->dependency_ready($_) } @distributions) {
         for my $dist (@dists) {
-            my $distfile = $dist->distfile;
-            if (($dist->{_runtime_waiting_distfiles} || $dist->{_runtime_waiting_packages}) && !$self->{runtime_dirty}{$distfile}) {
+            my $dependency_index = $self->{dependency_index};
+            if ($dependency_index->has_runtime_waiting($dist) && !$dependency_index->is_runtime_dirty($dist)) {
                 next;
             }
             my $dist_requirements = $dist->requirements('runtime')->as_array;
             my ($is_satisfied, @need_resolve) = $self->is_satisfied($dist_requirements);
             if ($is_satisfied) {
-                $self->_clear_runtime_waiting($dist);
+                $dependency_index->clear_runtime_waiting($dist);
                 $self->dependency_ready($dist, 1);
                 $changed++;
             } elsif (!defined $is_satisfied) {
-                $self->_clear_runtime_waiting($dist);
+                $dependency_index->clear_runtime_waiting($dist);
                 local $ctx->{logger}{context} = $dist->distvname;
                 my ($req) = grep { $_->{package} eq "perl" } $dist_requirements->@*;
                 my $msg = sprintf "%s requires perl %s, but you have only %s",
@@ -458,10 +404,10 @@ sub _mark_built_dependency_ready ($self, $ctx) {
                 $ctx->log($msg);
                 my $ok = $self->_register_resolve_task($ctx, @need_resolve);
                 $self->{_fail_install}{$dist->distfile}++ if !$ok;
-                $self->_remember_runtime_waiting($dist, $dist_requirements);
+                $dependency_index->remember_runtime_waiting($dist, $self->_runtime_waiting_for($dist_requirements));
                 $changed++;
             } else {
-                $self->_remember_runtime_waiting($dist, $dist_requirements);
+                $dependency_index->remember_runtime_waiting($dist, $self->_runtime_waiting_for($dist_requirements));
             }
         }
     }
@@ -738,8 +684,8 @@ sub add_distribution ($self, $distribution) {
     my $distfile = $distribution->distfile;
     if (my $already = $self->{distributions}{$distfile}) {
         delete $self->{_resolved_distribution};
-        $self->_index_provides($already, $distribution->provides);
-        $self->_mark_runtime_package_waiters_dirty(map { $_->{package} } $distribution->provides->@*);
+        $self->{dependency_index}->index_provides($already, $distribution->provides);
+        $self->{dependency_index}->mark_packages_resolved(map { $_->{package} } $distribution->provides->@*);
         if ($already->resolved) {
             $already->overwrite_provide($_) for $distribution->provides->@*;
         }
@@ -747,8 +693,8 @@ sub add_distribution ($self, $distribution) {
     } else {
         $self->{distributions}{$distfile} = $distribution;
         delete $self->{_resolved_distribution};
-        $self->_index_provides($distribution, $distribution->provides);
-        $self->_mark_runtime_package_waiters_dirty(map { $_->{package} } $distribution->provides->@*);
+        $self->{dependency_index}->index_provides($distribution, $distribution->provides);
+        $self->{dependency_index}->mark_packages_resolved(map { $_->{package} } $distribution->provides->@*);
         return 1;
     }
 }

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -222,7 +222,7 @@ sub dependency_env_for ($self, $dist, $phases, $seen = undef, $found = undef) {
             next if $self->is_installed($package, $version_range);
             next;
         }
-        next if !$self->{dependency_tracker}->dependency_ready($resolved);
+        next if !$self->{dependency_tracker}->is_dependency_ready($resolved);
         next if $seen->{$resolved->distfile}++;
 
         $found->{$resolved->distfile} = $resolved;
@@ -242,7 +242,7 @@ sub dependency_env_for ($self, $dist, $phases, $seen = undef, $found = undef) {
 }
 
 sub _final_install_distributions ($self, $include_unready = 0) {
-    return grep { $include_unready || $self->{dependency_tracker}->dependency_ready($_) } $self->distributions
+    return grep { $include_unready || $self->{dependency_tracker}->is_dependency_ready($_) } $self->distributions
         if $self->{final_install} eq "all";
 
     my %seen;
@@ -250,7 +250,7 @@ sub _final_install_distributions ($self, $include_unready = 0) {
     my @install;
     while (my $dist = shift @todo) {
         next if $seen{$dist->distfile}++;
-        push @install, $dist if $include_unready || $self->{dependency_tracker}->dependency_ready($dist);
+        push @install, $dist if $include_unready || $self->{dependency_tracker}->is_dependency_ready($dist);
 
         for my $req ($dist->requirements('runtime')->as_array->@*) {
             my ($package, $version_range) = $req->@{qw(package version_range)};
@@ -333,20 +333,20 @@ sub _add_tasks ($self, $ctx) {
 sub _mark_built_dependency_ready ($self, $ctx) {
     my $changed = 0;
     my @distributions = grep { !$self->{_fail_install}{$_->distfile} } $self->distributions;
-    if (my @dists = grep { $_->built && !$self->{dependency_tracker}->dependency_ready($_) } @distributions) {
+    if (my @dists = grep { $_->built && !$self->{dependency_tracker}->is_dependency_ready($_) } @distributions) {
         for my $dist (@dists) {
             my $dependency_tracker = $self->{dependency_tracker};
-            if ($dependency_tracker->has_runtime_waiting($dist) && !$dependency_tracker->is_runtime_dirty($dist)) {
+            if ($dependency_tracker->has_runtime_dependency_waiting($dist) && !$dependency_tracker->is_runtime_dependency_dirty($dist)) {
                 next;
             }
             my $dist_requirements = $dist->requirements('runtime')->as_array;
             my ($is_satisfied, @need_resolve) = $self->is_satisfied($dist_requirements);
             if ($is_satisfied) {
-                $dependency_tracker->clear_runtime_waiting($dist);
-                $self->{dependency_tracker}->dependency_ready($dist, 1);
+                $dependency_tracker->clear_runtime_dependency_waiting($dist);
+                $self->{dependency_tracker}->mark_dependency_ready($dist);
                 $changed++;
             } elsif (!defined $is_satisfied) {
-                $dependency_tracker->clear_runtime_waiting($dist);
+                $dependency_tracker->clear_runtime_dependency_waiting($dist);
                 local $ctx->{logger}{context} = $dist->distvname;
                 my ($req) = grep { $_->{package} eq "perl" } $dist_requirements->@*;
                 my $msg = sprintf "%s requires perl %s, but you have only %s",
@@ -363,18 +363,18 @@ sub _mark_built_dependency_ready ($self, $ctx) {
                 $ctx->log($msg);
                 my $ok = $self->_register_resolve_task($ctx, @need_resolve);
                 $self->{_fail_install}{$dist->distfile}++ if !$ok;
-                $dependency_tracker->remember_runtime_waiting($dist, $self->_runtime_waiting_for($dist_requirements));
+                $dependency_tracker->remember_runtime_dependency_waiting($dist, $self->_runtime_dependency_waiting_for($dist_requirements));
                 $changed++;
             } else {
-                $dependency_tracker->remember_runtime_waiting($dist, $self->_runtime_waiting_for($dist_requirements));
+                $dependency_tracker->remember_runtime_dependency_waiting($dist, $self->_runtime_dependency_waiting_for($dist_requirements));
             }
         }
     }
     return $changed;
 }
 
-sub _runtime_waiting_for ($self, $requirements) {
-    my (%wait_distfile, %wait_package);
+sub _runtime_dependency_waiting_for ($self, $requirements) {
+    my (%waiting_distfiles, %waiting_packages);
     for my $req ($requirements->@*) {
         my ($package, $version_range) = $req->@{qw(package version_range)};
         next if $package eq "perl";
@@ -382,20 +382,20 @@ sub _runtime_waiting_for ($self, $requirements) {
 
         my $resolved = $self->{dependency_tracker}->resolved_distribution($package, $version_range);
         if ($resolved) {
-            next if $self->{dependency_tracker}->dependency_ready($resolved);
-            $wait_distfile{$resolved->distfile} = 1;
+            next if $self->{dependency_tracker}->is_dependency_ready($resolved);
+            $waiting_distfiles{$resolved->distfile} = 1;
         } else {
             next if $self->is_installed($package, $version_range);
-            $wait_package{$package} = 1;
+            $waiting_packages{$package} = 1;
         }
     }
-    (\%wait_distfile, \%wait_package);
+    (\%waiting_distfiles, \%waiting_packages);
 }
 
 sub _mark_tested_dependency_ready ($self, $ctx) {
     my @distributions = grep { !$self->{_fail_install}{$_->distfile} } $self->distributions;
-    my @dists = grep { $_->tested && !$self->{dependency_tracker}->dependency_ready($_) } @distributions;
-    $self->{dependency_tracker}->dependency_ready($_, 1) for @dists;
+    my @dists = grep { $_->tested && !$self->{dependency_tracker}->is_dependency_ready($_) } @distributions;
+    $self->{dependency_tracker}->mark_dependency_ready($_) for @dists;
     return scalar @dists;
 }
 
@@ -645,7 +645,7 @@ sub is_satisfied ($self, $requirements) {
         next if $self->{target_perl} and $self->is_core($package, $version_range);
         my $resolved = $self->{dependency_tracker}->resolved_distribution($package, $version_range);
         if ($resolved) {
-            next if $self->{dependency_tracker}->dependency_ready($resolved);
+            next if $self->{dependency_tracker}->is_dependency_ready($resolved);
         } else {
             next if $self->is_installed($package, $version_range);
         }
@@ -662,7 +662,7 @@ sub add_distribution ($self, $distribution) {
     my $distfile = $distribution->distfile;
     if (my $already = $self->{distributions}{$distfile}) {
         $self->{dependency_tracker}->add_provides($already, $distribution->provides);
-        $self->{dependency_tracker}->mark_packages_resolved(map { $_->{package} } $distribution->provides->@*);
+        $self->{dependency_tracker}->mark_resolved_packages(map { $_->{package} } $distribution->provides->@*);
         if ($already->resolved) {
             $already->overwrite_provide($_) for $distribution->provides->@*;
         }
@@ -670,7 +670,7 @@ sub add_distribution ($self, $distribution) {
     } else {
         $self->{distributions}{$distfile} = $distribution;
         $self->{dependency_tracker}->add_provides($distribution, $distribution->provides);
-        $self->{dependency_tracker}->mark_packages_resolved(map { $_->{package} } $distribution->provides->@*);
+        $self->{dependency_tracker}->mark_resolved_packages(map { $_->{package} } $distribution->provides->@*);
         return 1;
     }
 }

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -661,7 +661,7 @@ sub is_satisfied ($self, $requirements) {
 sub add_distribution ($self, $distribution) {
     my $distfile = $distribution->distfile;
     if (my $already = $self->{distributions}{$distfile}) {
-        $self->{dependency_tracker}->index_provides($already, $distribution->provides);
+        $self->{dependency_tracker}->add_provides($already, $distribution->provides);
         $self->{dependency_tracker}->mark_packages_resolved(map { $_->{package} } $distribution->provides->@*);
         if ($already->resolved) {
             $already->overwrite_provide($_) for $distribution->provides->@*;
@@ -669,7 +669,7 @@ sub add_distribution ($self, $distribution) {
         return 0;
     } else {
         $self->{distributions}{$distfile} = $distribution;
-        $self->{dependency_tracker}->index_provides($distribution, $distribution->provides);
+        $self->{dependency_tracker}->add_provides($distribution, $distribution->provides);
         $self->{dependency_tracker}->mark_packages_resolved(map { $_->{package} } $distribution->provides->@*);
         return 1;
     }

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -19,7 +19,11 @@ sub new ($class, %argv) {
         installed_distributions => 0,
         tasks => +{},
         distributions => +{},
+        provided_by_package => +{},
         dependency_ready => +{},
+        runtime_waiting_by_distfile => +{},
+        runtime_waiting_by_package => +{},
+        runtime_dirty => +{},
         _fail_resolve => +{},
         _fail_install => +{},
         _is_installed => +{},
@@ -209,17 +213,94 @@ sub install_phase_state ($self, $dist) {
 
 sub dependency_ready ($self, $dist, @argv) {
     my $distfile = $dist->distfile;
-    $self->{dependency_ready}{$distfile} = $argv[0] ? 1 : 0 if @argv;
+    if (@argv) {
+        my $ready = $argv[0] ? 1 : 0;
+        my $was_ready = $self->{dependency_ready}{$distfile} || 0;
+        $self->{dependency_ready}{$distfile} = $ready;
+        $self->_mark_runtime_waiters_dirty($distfile) if !$was_ready && $ready;
+    }
     $self->{dependency_ready}{$distfile};
+}
+
+sub _mark_runtime_waiters_dirty ($self, $distfile) {
+    if (my $waiters = $self->{runtime_waiting_by_distfile}{$distfile}) {
+        $self->{runtime_dirty}{$_} = 1 for keys $waiters->%*;
+    }
+}
+
+sub _mark_runtime_package_waiters_dirty ($self, @package) {
+    for my $package (@package) {
+        if (my $waiters = $self->{runtime_waiting_by_package}{$package}) {
+            $self->{runtime_dirty}{$_} = 1 for keys $waiters->%*;
+        }
+    }
+}
+
+sub _clear_runtime_waiting ($self, $dist) {
+    my $distfile = $dist->distfile;
+    my $waiting_distfiles = $dist->{_runtime_waiting_distfiles} || {};
+    for my $wait_distfile (keys $waiting_distfiles->%*) {
+        delete $self->{runtime_waiting_by_distfile}{$wait_distfile}{$distfile};
+        delete $self->{runtime_waiting_by_distfile}{$wait_distfile}
+            if !keys $self->{runtime_waiting_by_distfile}{$wait_distfile}->%*;
+    }
+    my $waiting_packages = $dist->{_runtime_waiting_packages} || {};
+    for my $package (keys $waiting_packages->%*) {
+        delete $self->{runtime_waiting_by_package}{$package}{$distfile};
+        delete $self->{runtime_waiting_by_package}{$package}
+            if !keys $self->{runtime_waiting_by_package}{$package}->%*;
+    }
+    delete $dist->{_runtime_waiting_distfiles};
+    delete $dist->{_runtime_waiting_packages};
+    delete $self->{runtime_dirty}{$distfile};
+}
+
+sub _remember_runtime_waiting ($self, $dist, $requirements) {
+    my $distfile = $dist->distfile;
+    $self->_clear_runtime_waiting($dist);
+
+    my (%wait_distfile, %wait_package);
+    for my $req ($requirements->@*) {
+        my ($package, $version_range) = $req->@{qw(package version_range)};
+        next if $package eq "perl";
+        next if $self->{target_perl} and $self->is_core($package, $version_range);
+
+        my $resolved = $self->_resolved_distribution($package, $version_range);
+        if ($resolved) {
+            next if $self->dependency_ready($resolved);
+            $wait_distfile{$resolved->distfile} = 1;
+        } else {
+            next if $self->is_installed($package, $version_range);
+            $wait_package{$package} = 1;
+        }
+    }
+
+    if (%wait_distfile || %wait_package) {
+        $dist->{_runtime_waiting_distfiles} = \%wait_distfile;
+        $dist->{_runtime_waiting_packages} = \%wait_package;
+        $self->{runtime_waiting_by_distfile}{$_}{$distfile} = 1 for keys %wait_distfile;
+        $self->{runtime_waiting_by_package}{$_}{$distfile} = 1 for keys %wait_package;
+    }
 }
 
 sub _resolved_distribution ($self, $package, $version_range = undef) {
     my $key = join "\0", $package, $version_range // "";
     return $self->{_resolved_distribution}{$key} if exists $self->{_resolved_distribution}{$key};
 
-    my ($resolved) = grep { $_->providing($package, $version_range) } $self->distributions;
+    my $candidates = $self->{provided_by_package}{$package} || [];
+    my ($resolved) = grep { $_->providing($package, $version_range) } $candidates->@*;
     $self->{_resolved_distribution}{$key} = $resolved;
     $resolved;
+}
+
+sub _index_provides ($self, $distribution, $provides) {
+    my $distfile = $distribution->distfile;
+    for my $provide ($provides->@*) {
+        my $package = $provide->{package};
+        my $candidates = $self->{provided_by_package}{$package} ||= [];
+        push $candidates->@*, $distribution
+            if !grep { $_->distfile eq $distfile } $candidates->@*;
+    }
 }
 
 sub dependency_env_for ($self, $dist, $phases, $seen = undef, $found = undef) {
@@ -349,12 +430,18 @@ sub _mark_built_dependency_ready ($self, $ctx) {
     my @distributions = grep { !$self->{_fail_install}{$_->distfile} } $self->distributions;
     if (my @dists = grep { $_->built && !$self->dependency_ready($_) } @distributions) {
         for my $dist (@dists) {
+            my $distfile = $dist->distfile;
+            if (($dist->{_runtime_waiting_distfiles} || $dist->{_runtime_waiting_packages}) && !$self->{runtime_dirty}{$distfile}) {
+                next;
+            }
             my $dist_requirements = $dist->requirements('runtime')->as_array;
             my ($is_satisfied, @need_resolve) = $self->is_satisfied($dist_requirements);
             if ($is_satisfied) {
+                $self->_clear_runtime_waiting($dist);
                 $self->dependency_ready($dist, 1);
                 $changed++;
             } elsif (!defined $is_satisfied) {
+                $self->_clear_runtime_waiting($dist);
                 local $ctx->{logger}{context} = $dist->distvname;
                 my ($req) = grep { $_->{package} eq "perl" } $dist_requirements->@*;
                 my $msg = sprintf "%s requires perl %s, but you have only %s",
@@ -371,7 +458,10 @@ sub _mark_built_dependency_ready ($self, $ctx) {
                 $ctx->log($msg);
                 my $ok = $self->_register_resolve_task($ctx, @need_resolve);
                 $self->{_fail_install}{$dist->distfile}++ if !$ok;
+                $self->_remember_runtime_waiting($dist, $dist_requirements);
                 $changed++;
+            } else {
+                $self->_remember_runtime_waiting($dist, $dist_requirements);
             }
         }
     }
@@ -622,7 +712,6 @@ sub is_core ($self, $package, $version_range) {
 sub is_satisfied ($self, $requirements) {
     my $is_satisfied = 1;
     my @need_resolve;
-    my @distributions = $self->distributions;
     for my $req ($requirements->@*) {
         my ($package, $version_range) = $req->@{qw(package version_range)};
         if ($package eq "perl") {
@@ -648,14 +737,18 @@ sub is_satisfied ($self, $requirements) {
 sub add_distribution ($self, $distribution) {
     my $distfile = $distribution->distfile;
     if (my $already = $self->{distributions}{$distfile}) {
+        delete $self->{_resolved_distribution};
+        $self->_index_provides($already, $distribution->provides);
+        $self->_mark_runtime_package_waiters_dirty(map { $_->{package} } $distribution->provides->@*);
         if ($already->resolved) {
             $already->overwrite_provide($_) for $distribution->provides->@*;
-            delete $self->{_resolved_distribution};
         }
         return 0;
     } else {
         $self->{distributions}{$distfile} = $distribution;
         delete $self->{_resolved_distribution};
+        $self->_index_provides($distribution, $distribution->provides);
+        $self->_mark_runtime_package_waiters_dirty(map { $_->{package} } $distribution->provides->@*);
         return 1;
     }
 }

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -20,7 +20,6 @@ sub new ($class, %argv) {
         installed_distributions => 0,
         tasks => +{},
         distributions => +{},
-        dependency_ready => +{},
         dependency_index => App::cpm::DependencyIndex->new,
         _fail_resolve => +{},
         _fail_install => +{},
@@ -210,14 +209,7 @@ sub install_phase_state ($self, $dist) {
 }
 
 sub dependency_ready ($self, $dist, @argv) {
-    my $distfile = $dist->distfile;
-    if (@argv) {
-        my $ready = $argv[0] ? 1 : 0;
-        my $was_ready = $self->{dependency_ready}{$distfile} || 0;
-        $self->{dependency_ready}{$distfile} = $ready;
-        $self->{dependency_index}->mark_distfile_ready($distfile) if !$was_ready && $ready;
-    }
-    $self->{dependency_ready}{$distfile};
+    $self->{dependency_index}->dependency_ready($dist, @argv);
 }
 
 sub _runtime_waiting_for ($self, $requirements) {
@@ -240,13 +232,7 @@ sub _runtime_waiting_for ($self, $requirements) {
 }
 
 sub _resolved_distribution ($self, $package, $version_range = undef) {
-    my $key = join "\0", $package, $version_range // "";
-    return $self->{_resolved_distribution}{$key} if exists $self->{_resolved_distribution}{$key};
-
-    my ($resolved) = grep { $_->providing($package, $version_range) }
-        $self->{dependency_index}->providers_for($package);
-    $self->{_resolved_distribution}{$key} = $resolved;
-    $resolved;
+    $self->{dependency_index}->resolved_distribution($package, $version_range);
 }
 
 sub dependency_env_for ($self, $dist, $phases, $seen = undef, $found = undef) {
@@ -683,7 +669,6 @@ sub is_satisfied ($self, $requirements) {
 sub add_distribution ($self, $distribution) {
     my $distfile = $distribution->distfile;
     if (my $already = $self->{distributions}{$distfile}) {
-        delete $self->{_resolved_distribution};
         $self->{dependency_index}->index_provides($already, $distribution->provides);
         $self->{dependency_index}->mark_packages_resolved(map { $_->{package} } $distribution->provides->@*);
         if ($already->resolved) {
@@ -692,7 +677,6 @@ sub add_distribution ($self, $distribution) {
         return 0;
     } else {
         $self->{distributions}{$distfile} = $distribution;
-        delete $self->{_resolved_distribution};
         $self->{dependency_index}->index_provides($distribution, $distribution->provides);
         $self->{dependency_index}->mark_packages_resolved(map { $_->{package} } $distribution->provides->@*);
         return 1;


### PR DESCRIPTION
## Summary

This PR improves cpm's parent-side dependency readiness scheduling for large install graphs.

- Track dependency-ready distributions and runtime dependency waiters in `App::cpm::DependencyTracker`.
- Cache package requirement resolution through the tracker.
- Mark only affected runtime dependency waiters dirty when a dist becomes dependency-ready or a package is newly resolved.
- Keep install scheduling decisions in `App::cpm::Master`, while moving state/index/cache ownership into the tracker.

## Why

On small Linux VPS environments, repeated full scans of built distributions made parent-side scheduling noticeably slow during installs with many modules. The expensive path was checking runtime dependency satisfaction across many candidates after each worker result.

The tracker narrows those repeat checks to distributions whose unresolved runtime dependency state may actually have changed.