### PR TITLE
Prefer installed modules before waiting on unresolved dists

### DIFF
--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -633,9 +633,8 @@ sub is_satisfied ($self, $requirements) {
         my $resolved = $self->_resolved_distribution($package, $version_range);
         if ($resolved) {
             next if $self->dependency_ready($resolved);
-        } else {
-            next if $self->is_installed($package, $version_range);
         }
+        next if $self->is_installed($package, $version_range);
 
         $is_satisfied = 0 if defined $is_satisfied;
         if (!$resolved) {

--- a/xt/41_issue.t
+++ b/xt/41_issue.t
@@ -1,0 +1,19 @@
+use v5.24;
+use warnings;
+use experimental qw(lexical_subs signatures);
+
+use Test::More;
+use lib "xt/lib";
+use CLI;
+
+subtest argv => sub () {
+    # ExtUtils::MakeMaker depends on Encode
+    # https://metacpan.org/release/BINGOS/ExtUtils-MakeMaker-7.78/source/META.json#L39
+    #
+    # Encode depends on ExtUtils::MakeMaker
+    # https://metacpan.org/release/DANKOGAI/Encode-3.24/source/META.json#L30
+    my $res = cpm_install 'ExtUtils::MakeMaker', 'Encode';
+    is $res->exit, 0 or diag $res->log;
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

Fixes #297.

This fixes the minimal reproduction from #297 where installing `ExtUtils::MakeMaker` and `Encode` together was reported as a circular dependency even though both modules can be used from the current `@INC` while bootstrapping the requested installs.

The dependency satisfaction order was effectively:

1. Handle `perl` and core modules with the existing rules.
2. If a resolved distribution provides the requirement and is ready, treat it as satisfied.
3. If a resolved distribution provides the requirement but is not ready, wait for it.
4. Only when no resolved distribution exists, check whether `@INC` already satisfies the requirement.
5. Otherwise resolve the requirement.

This PR changes that order to:

1. Handle `perl` and core modules with the existing rules.
2. If an already-ready distribution provides the requirement, treat it as satisfied.
3. If the current `@INC` satisfies the requirement, treat it as satisfied.
4. If an unresolved or unready distribution provides the requirement, wait for it.
5. Otherwise resolve the requirement.

With this ordering, `ExtUtils::MakeMaker` can use the existing `Encode` from `@INC`, and `Encode` can use the existing `ExtUtils::MakeMaker` from `@INC`, while both requested distributions are still installed as top-level targets.

## Scope

This intentionally keeps the first fix small: it only changes the satisfaction ordering and adds `xt/41_issue.t` for the issue reproduction.

A larger follow-up would track whether a dependency was satisfied through `@INC` or through an `App::cpm::Distribution` more explicitly. That would let cpm reason about provider choices more accurately across phases, but this PR avoids taking on that broader dependency-planning refactor before the immediate installability regression is fixed.

## Tests

- `prove -l --jobs 4 t xt`