### PR TITLE
[codex] Add Perl version reporting to user agent

### DIFF
--- a/lib/App/cpm/CLI.pm
+++ b/lib/App/cpm/CLI.pm
@@ -60,8 +60,13 @@ sub new ($class, %argv) {
         static_install => 1,
         use_install_command => 0,
         default_resolvers => 1,
+        report_perl_version => !$class->maybe_ci,
         %argv
     }, $class;
+}
+
+sub maybe_ci ($class) {
+    !!grep $ENV{$_}, qw(CI AUTOMATED_TESTING AUTHOR_TESTING);
 }
 
 sub _normalize_progress ($self, $progress) {
@@ -107,7 +112,7 @@ sub _warn_deprecated_top_level_option ($self, $option) {
 }
 
 sub _progress_default ($self) {
-    !WIN32 && !$ENV{CI} && !$self->{verbose} && -t STDERR && terminal_width > 60 ? "tty" : "plain";
+    !WIN32 && !$self->maybe_ci && !$self->{verbose} && -t STDERR && terminal_width > 60 ? "tty" : "plain";
 }
 
 sub parse_options ($self, @argv) {
@@ -174,6 +179,7 @@ sub parse_options ($self, @argv) {
         "pp|pureperl|pureperl-only" => \($self->{pureperl_only}),
         "static-install!" => \($self->{static_install}),
         "use-install-command!" => \($self->{use_install_command}),
+        "report-perl-version!" => \($self->{report_perl_version}),
         "top-level-phase=s" => \$top_level_phase,
         "top-level-relationship=s" => \$top_level_relationship,
         "with-all" => sub (@) {
@@ -329,7 +335,10 @@ sub cmd_install ($self) {
     my $work_dir = File::Spec->catdir($self->{home}, "work", "$now.$$");
     my $cache_dir = File::Spec->catdir($self->{home}, "cache");
 
-    my $ctx = App::cpm::Context->new(log_file => $log_file);
+    my $ctx = App::cpm::Context->new(
+        log_file => $log_file,
+        report_perl_version => $self->{report_perl_version},
+    );
     $ctx->{logger}->symlink_to("$self->{home}/build.log");
     my $trial = $App::cpm::TRIAL ? '-TRIAL' : '';
     $ctx->log("Running cpm $App::cpm::VERSION$trial ($0) on perl $Config{version} built for $Config{archname} ($^X)");
@@ -873,6 +882,8 @@ Options:
         no-op compatibility option, will be removed in a future release
       --show-build-log-on-failure
         show build.log on failure, default: off
+      --report-perl-version, --no-report-perl-version
+        report your local perl version as part of User-Agent, default: on unless CI is enabled
       --configure-timeout=sec, --build-timeout=sec, --test-timeout=sec
         specify configure/build/test timeout second, default: 60sec, 3600sec, 1800sec
       --progress=auto|tty|plain

--- a/lib/App/cpm/Context.pm
+++ b/lib/App/cpm/Context.pm
@@ -12,7 +12,9 @@ use File::Which ();
 
 sub new ($class, %argv) {
     my $logger = App::cpm::Logger::File->new($argv{log_file});
-    my ($http, $http_description) = App::cpm::HTTP->create;
+    my ($http, $http_description) = App::cpm::HTTP->create(
+        report_perl_version => $argv{report_perl_version},
+    );
     my $unpacker = App::cpm::Installer::Unpacker->new;
     my $make = File::Which::which($Config{make});
     bless {

--- a/lib/App/cpm/HTTP.pm
+++ b/lib/App/cpm/HTTP.pm
@@ -33,9 +33,11 @@ package App::cpm::HTTP::_HTTPTiny {
     }
 }
 
-
 sub create ($class, %args) {
     my $wantarray = wantarray;
+    my $report_perl_version = delete $args{report_perl_version};
+    my $agent = "App::cpm/$App::cpm::VERSION";
+    $agent .= " perl/$]" if $report_perl_version;
 
     my @try = $args{prefer} ? $args{prefer}->@* : qw(HTTPTiny LWP Curl Wget);
     @try = map { "HTTP::Tinyish::$_" } @try;
@@ -52,7 +54,7 @@ sub create ($class, %args) {
     die "Couldn't find HTTP Clients that support https" if !$backend;
 
     my $http = $backend->new(
-        agent => "App::cpm/$App::cpm::VERSION",
+        agent => $agent,
         timeout => 60,
         verify_SSL => 1,
         %args,

--- a/xt/40_cli_options.t
+++ b/xt/40_cli_options.t
@@ -26,4 +26,31 @@ subtest no_use_install_command_keeps_prebuilt => sub () {
     is $cli->{prebuilt}, 1;
 };
 
+subtest report_perl_version_defaults_to_on => sub () {
+    local @ENV{qw(CI AUTOMATED_TESTING AUTHOR_TESTING)};
+    my $cli = App::cpm::CLI->new;
+    ok $cli->parse_options("ModuleA");
+    is $cli->{report_perl_version}, 1;
+};
+
+subtest report_perl_version_defaults_to_off_on_ci => sub () {
+    local $ENV{CI} = 1;
+    my $cli = App::cpm::CLI->new;
+    ok $cli->parse_options("ModuleA");
+    ok !$cli->{report_perl_version};
+};
+
+subtest no_report_perl_version_disables_reporting => sub () {
+    my $cli = App::cpm::CLI->new;
+    ok $cli->parse_options("--no-report-perl-version", "ModuleA");
+    is $cli->{report_perl_version}, 0;
+};
+
+subtest report_perl_version_overrides_ci_default => sub () {
+    local $ENV{CI} = 1;
+    my $cli = App::cpm::CLI->new;
+    ok $cli->parse_options("--report-perl-version", "ModuleA");
+    is $cli->{report_perl_version}, 1;
+};
+
 done_testing;

--- a/xt/42_http.t
+++ b/xt/42_http.t
@@ -1,0 +1,20 @@
+use v5.24;
+use warnings;
+use experimental qw(lexical_subs signatures);
+
+use Test::More;
+
+use App::cpm;
+use App::cpm::HTTP;
+
+subtest report_perl_version => sub () {
+    my $http = App::cpm::HTTP->create(report_perl_version => 1);
+    is($http->{agent} || $http->{_new_argv}{agent}, "App::cpm/$App::cpm::VERSION perl/$]", "reports Perl version in User-Agent");
+};
+
+subtest no_report_perl_version => sub () {
+    my $http = App::cpm::HTTP->create(report_perl_version => 0);
+    is($http->{agent} || $http->{_new_argv}{agent}, "App::cpm/$App::cpm::VERSION", "can omit Perl version from User-Agent");
+};
+
+done_testing;


### PR DESCRIPTION
Report the local Perl version in cpm's User-Agent so CPAN MetaDB can count cpm usage alongside cpanm-style Perl version stats. The reporting is enabled by default outside CI, with an explicit opt-out for users who do not want to send it.

Example User-Agent: `App::cpm/v1.0.4 perl/5.042002`