### PR TITLE
Verify downloaded artifacts against a resolver-supplied checksum

### DIFF
--- a/lib/App/cpm/Distribution.pm
+++ b/lib/App/cpm/Distribution.pm
@@ -63,6 +63,7 @@ for my $attr (qw(
     builder
     prebuilt
     final_target
+    checksum
 )) {
     no strict 'refs';
     *$attr = sub ($self, @argv) {

--- a/lib/App/cpm/Master.pm
+++ b/lib/App/cpm/Master.pm
@@ -398,6 +398,7 @@ sub _add_fetch_tasks ($self, $ctx) {
                 source => $dist->source,
                 uri => $dist->uri,
                 ref => $dist->ref,
+                checksum => $dist->checksum,
             );
             $changed++;
         }
@@ -708,6 +709,7 @@ sub _register_resolve_result ($self, $ctx, $task) {
         distfile => $task->{distfile},
         ref      => $task->{ref},
         final_target => $task->{final_target},
+        checksum => $task->{checksum},
     );
     if (!$self->add_distribution($distribution) && $task->{final_target}) {
         $self->distribution($distribution->distfile)->final_target(1);

--- a/lib/App/cpm/Worker/Installer.pm
+++ b/lib/App/cpm/Worker/Installer.pm
@@ -14,6 +14,7 @@ use App::cpm::version;
 use CPAN::DistnameInfo;
 use CPAN::Meta;
 use Config;
+use Digest::SHA ();
 use File::Basename 'basename';
 use File::Copy ();
 use File::Copy::Recursive ();
@@ -171,12 +172,14 @@ sub fetch ($self, $ctx, $task) {
     } elsif ($source =~ /^(?:cpan|https?)$/) {
         my $g = pushd $self->{work_dir};
 
+        my $checksum = $task->{checksum};
         FETCH: {
             my $basename = basename $uri;
             if ($uri =~ s{^file://}{}) {
                 $ctx->log("Copying $uri");
                 File::Copy::copy($uri, $basename)
                     or last FETCH;
+                last FETCH if $checksum and !$self->verify_checksum($ctx, $basename, $checksum);
                 $dir = $self->unpack($ctx, $basename);
             } else {
                 if ($distfile and trusted_mirror($uri)) {
@@ -184,15 +187,20 @@ sub fetch ($self, $ctx, $task) {
                     if (-f $cache) {
                         $ctx->log("Using cache $cache");
                         File::Copy::copy($cache, $basename);
-                        $dir = $self->unpack($ctx, $basename);
-                        if ($dir) {
-                            $using_cache++;
-                            last FETCH;
+                        if ($checksum and !$self->verify_checksum($ctx, $basename, $checksum)) {
+                            $ctx->log("Discarding cached artifact that failed checksum: $cache");
+                            unlink $cache, $basename;
+                        } else {
+                            $dir = $self->unpack($ctx, $basename);
+                            if ($dir) {
+                                $using_cache++;
+                                last FETCH;
+                            }
+                            unlink $cache;
                         }
-                        unlink $cache;
                     }
                 }
-                $dir = $self->fetch_distribution($ctx, $uri, $distfile);
+                $dir = $self->fetch_distribution($ctx, $uri, $distfile, $checksum);
             }
         }
         $dir = File::Spec->catdir($self->{work_dir}, $dir) if $dir;
@@ -440,6 +448,38 @@ sub extract_packages ($self, $ctx, $meta) {
     \@out;
 }
 
+# Verify a downloaded artifact against an expected digest supplied by the
+# resolver (e.g. from a committed integrity lockfile). $checksum is
+# "<algo>:<hex>" or a bare sha256 hex. Returns true on match; a false return
+# makes the caller abort this distribution before it is unpacked, cached, or
+# built.
+sub verify_checksum ($self, $ctx, $file, $checksum) {
+    my ($algo, $expect) = $checksum =~ /\A(?:([A-Za-z0-9]+):)?([0-9a-fA-F]+)\z/
+        ? (lc($1 // 'sha256'), lc $2) : ();
+    if (!$expect) {
+        $ctx->log("Malformed checksum '$checksum'");
+        return;
+    }
+    if ($algo ne 'sha256') {
+        $ctx->log("Unsupported checksum algorithm '$algo' (only sha256)");
+        return;
+    }
+    open my $fh, '<:raw', $file or do {
+        $ctx->log("Cannot read $file for checksum: $!");
+        return;
+    };
+    my $got = Digest::SHA->new(256)->addfile($fh)->hexdigest;
+    close $fh;
+    if ($got ne $expect) {
+        $ctx->log("Checksum MISMATCH for @{[basename $file]}");
+        $ctx->log("  expected sha256:$expect");
+        $ctx->log("  got      sha256:$got");
+        return;
+    }
+    $ctx->log("Verified sha256:$got");
+    return 1;
+}
+
 sub mirror ($self, $ctx, $uri, $local) {
     my $res = $ctx->{http}->mirror($uri, $local);
     $ctx->log($res->{status} . ($res->{reason} ? " $res->{reason}" : ""));
@@ -449,11 +489,15 @@ sub mirror ($self, $ctx, $uri, $local) {
     return;
 }
 
-sub fetch_distribution ($self, $ctx, $uri, $distfile) {
+sub fetch_distribution ($self, $ctx, $uri, $distfile, $checksum = undef) {
     my $local = File::Spec->catfile($self->{work_dir}, File::Basename::basename($uri));
     $ctx->log("Fetching $uri");
     if (!$self->mirror($ctx, $uri, $local)) {
         $ctx->log("Failed to download $uri");
+        return;
+    }
+    if ($checksum and !$self->verify_checksum($ctx, $local, $checksum)) {
+        unlink $local;
         return;
     }
     my $dir = $self->unpack($ctx, $local);


### PR DESCRIPTION
Today cpm performs no artifact-content verification: a resolver identifies a distribution, but the downloaded bytes are unpacked and built without ever being checked against an expected digest.

This lets a resolver attach an optional `checksum` (`sha256:<hex>` or bare hex) to its resolve result. `Worker::Installer::fetch` hashes the downloaded tarball and aborts the distribution **before it is unpacked, cached, or built** if the digest doesn't match; a poisoned cache entry is discarded and re-fetched. Distributions whose resolver supplies no checksum are unaffected — fully backward compatible. 3 files, +54/-7.

Motivation: install-time integrity enforcement (a resolver that reads pinned hashes from a committed lockfile). Demonstrated with a stock-vs-patched control on a *valid* wrong-hash artifact — stock cpm installs it, patched cpm refuses the same bytes: https://github.com/Conalh/cpan-integ/actions/runs/26689772758 (job `cpm-integrity`). Happy to add a test in your preferred style, and glad to discuss as an issue first if you'd rather scope the approach.
