### PR TITLE
automatically run make install when MY::install found, fix PERL5LIB

### DIFF
--- a/lib/App/cpm/Builder/Base.pm
+++ b/lib/App/cpm/Builder/Base.pm
@@ -70,8 +70,16 @@ sub _env_path ($self, $dependency_paths) {
 }
 
 sub _env_perl5lib ($self, $dependency_libs) {
+    # Always include install_base/lib/perl5 in PERL5LIB so that
+    # make install postambles (e.g. XML::SAX's install_sax_driver)
+    # can find modules that were just installed, even if the directory
+    # did not exist when this builder was first constructed.
+    my $install_lib = $self->{install_base}
+        ? File::Spec->catdir($self->{install_base}, "lib", "perl5")
+        : undef;
     join $Config{path_sep},
         $dependency_libs->@*,
+        ($install_lib ? $install_lib : ()),
         ($self->{local_perl5lib} ? $self->{local_perl5lib} : ()),
         ( $ENV{PERL5LIB} ? $ENV{PERL5LIB} : ());
 }
@@ -81,7 +89,7 @@ sub _set_env ($self, $dependency_libs, $dependency_paths) {
         $ENV{PATH} = $self->_env_path($dependency_paths);
     }
 
-    if ($dependency_libs->@* || $self->{local_perl5lib}) {
+    if ($dependency_libs->@* || $self->{local_perl5lib} || $self->{install_base}) {
         $ENV{PERL5LIB} = $self->_env_perl5lib($dependency_libs);
     }
 }

--- a/lib/App/cpm/Builder/EUMM.pm
+++ b/lib/App/cpm/Builder/EUMM.pm
@@ -9,13 +9,26 @@ sub supports ($class, @) {
     -f 'Makefile.PL';
 }
 
+sub _makefile_pl_has_postamble ($self) {
+    return 0 if !-f 'Makefile.PL';
+    open my $fh, '<', 'Makefile.PL' or return 0;
+    while (my $line = <$fh>) {
+        return 1 if $line =~ /MY::install|postamble/;
+    }
+    return 0;
+}
+
 sub configure ($self, $ctx, $dependency_libs, $dependency_paths) {
     if (!$ctx->{make}) {
         $ctx->log("There is Makefile.PL, but you don't have 'make' command; you should install 'make' command first");
         return;
     }
+    # Pre-detect postamble before Makefile.PL runs so INSTALL_BASE is passed
+    # when this distribution will need 'make install' rather than blib copy.
+    $self->{_needs_install_command} = $self->_makefile_pl_has_postamble;
     my @cmd = ($ctx->{perl}, 'Makefile.PL');
-    push @cmd, "INSTALL_BASE=$self->{install_base}" if $self->{use_install_command} && $self->{install_base};
+    push @cmd, "INSTALL_BASE=$self->{install_base}"
+        if $self->{install_base} && ($self->{use_install_command} || $self->{_needs_install_command});
     push @cmd, qw(INSTALLMAN1DIR=none INSTALLMAN3DIR=none) if $self->{need_noman_argv};
     push @cmd, 'PUREPERL_ONLY=1' if $self->{pureperl_only};
     push @cmd, $self->{argv}->@* if $self->{argv}->@*;
@@ -34,8 +47,27 @@ sub test ($self, $ctx, $dependency_libs, $dependency_paths) {
     $self->run_test($ctx, [ $ctx->{make}, "test" ], $dependency_libs, $dependency_paths);
 }
 
+# Detect whether the generated Makefile has a custom install target with
+# additional dependencies — i.e. a MY::install postamble. If so, we must
+# run 'make install' rather than copying from blib/ directly, otherwise
+# the postamble's actions (e.g. XML::SAX's install_sax_driver writing
+# ParserDetails.ini, DBD driver registration, etc.) are silently skipped.
+sub _has_install_postamble ($self) {
+    return 0 if !-f 'Makefile';
+    open my $fh, '<', 'Makefile' or return 0;
+    while (my $line = <$fh>) {
+        # A custom install target with extra prerequisites looks like:
+        #   install :: pure_install doc_install install_sax_driver
+        # i.e. the install target has dependencies beyond the standard ones.
+        return 1 if $line =~ /^install\s*:.*\binstall_/;
+    }
+    return 0;
+}
+
 sub install ($self, $ctx, $dependency_libs = [], $dependency_paths = []) {
-    return $self->SUPER::install($ctx, $dependency_libs, $dependency_paths) if !$self->{use_install_command};
+    if (!$self->{use_install_command} && !$self->{_needs_install_command} && !$self->_has_install_postamble) {
+        return $self->SUPER::install($ctx, $dependency_libs, $dependency_paths);
+    }
     my $ok = $self->run_install($ctx, [ $ctx->{make}, "install" ], $dependency_libs, $dependency_paths);
     return if !$ok;
     $self->_install_blib_meta($ctx);
@@ -43,7 +75,7 @@ sub install ($self, $ctx, $dependency_libs = [], $dependency_paths = []) {
 }
 
 sub needs_install_env ($self) {
-    return $self->{use_install_command} ? 1 : 0;
+    return ($self->{use_install_command} || $self->{_needs_install_command} || $self->_has_install_postamble) ? 1 : 0;
 }
 
 1;


### PR DESCRIPTION
# Fix: correctly handle ExtUtils::MakeMaker postambles when installing to a local lib

## Summary

Two related fixes that bring `cpm`'s behavior in line with `cpanm` when
installing distributions that define `ExtUtils::MakeMaker` postambles:

1. **`Base.pm`** — set `PERL5LIB` to include `install_base/lib/perl5` when
   running `make install`, so postambles have access to modules just installed
   there (matching `cpanm`'s behavior)

2. **`EUMM.pm`** — automatically detect distributions with `MY::install`
   postambles and use `make install` for them, without requiring
   `--use-install-command`

## Background

`ExtUtils::MakeMaker` provides a `MY::install` hook that module authors use
to perform post-install steps beyond copying files. A widespread example is
`XML::SAX`, which registers its parser backend by writing `ParserDetails.ini`
during `make install`:

```makefile
install_sax_pureperl:
    @$(PERL) -MXML::SAX -e "XML::SAX->add_parser(q(XML::SAX::PurePerl))->save_parsers()"
```

Without this step, `XML::SAX::ParserFactory` warns about a missing
`ParserDetails.ini` on every use. Other affected modules include
`XML::SAX::Expat`, `DBD::*` drivers, and any distribution that registers
itself or writes configuration during install.

## Reproducing the Problem

On a clean system with no `XML::SAX` installed anywhere:

```bash
rm -rf /tmp/local
cpm install --use-install-command -L /tmp/local XML::SAX
# FAIL install XML-SAX-1.02
# could not find ParserDetails.ini in /tmp/local/lib/perl5/XML/SAX
```

The same install with `cpanm` succeeds:

```bash
rm -rf /tmp/local
cpanm -L /tmp/local XML::SAX
# Successfully installed XML-SAX-1.02
# ParserDetails.ini written correctly
```

## Root Cause

### Bug 1 — `PERL5LIB` not set during `make install` (Base.pm)

`cpm` runs `make install` (when `--use-install-command` is given) but does
not set `PERL5LIB` to include `install_base/lib/perl5`. When the postamble
runs `perl -MXML::SAX`, the just-installed `XML::SAX.pm` (in
`/tmp/local/lib/perl5/`) is not in `@INC` — the postamble fails loudly with
"Can't locate XML/SAX.pm".

`cpanm` correctly sets `PERL5LIB` to include the install target before running
`make install`, which is why it succeeds.

The condition in `_set_env`:

```perl
if ($dependency_libs->@* || $self->{local_perl5lib}) {
    $ENV{PERL5LIB} = ...;
}
```

is never true for a fresh install: `dependency_libs` is empty (the
distribution's deps don't provide libs) and `local_perl5lib` is undef because
`local/lib/perl5` didn't exist when `cpm` started. `PERL5LIB` is therefore
never set, and the postamble runs with a broken environment.

### Bug 2 — postambles only run with `--use-install-command` (EUMM.pm)

`cpm` installs by copying files from `blib/` rather than running `make
install`, which is faster but skips `MY::install` postambles entirely. The
`--use-install-command` flag enables `make install`, but:

- It must be set globally — there is no per-distribution detection
- Users cannot reasonably know which distributions require it
- Without it, postambles are silently skipped

## Fix

### Base.pm — always include `install_base/lib/perl5` in `PERL5LIB`

`_env_perl5lib` now always includes `install_base/lib/perl5` when `install_base`
is set, regardless of whether the directory existed at startup. `_set_env` is
updated to set `PERL5LIB` whenever `install_base` is set.

This matches what `cpanm` does and ensures postambles that invoke
`perl -MSome::Module` can find modules installed earlier in the same run.

```perl
# Before
if ($dependency_libs->@* || $self->{local_perl5lib}) {
    $ENV{PERL5LIB} = $self->_env_perl5lib($dependency_libs);
}

# After  
if ($dependency_libs->@* || $self->{local_perl5lib} || $self->{install_base}) {
    $ENV{PERL5LIB} = $self->_env_perl5lib($dependency_libs);
}
```

### EUMM.pm — auto-detect postambles, use `make install` when needed

Two detection points, neither requiring `--use-install-command`:

**Pre-configure** (`_makefile_pl_has_postamble`): scan `Makefile.PL` for
`MY::install` or `postamble` before running it. If found, set
`_needs_install_command` and ensure `INSTALL_BASE` is passed to `Makefile.PL`
so the generated `Makefile` bakes in the correct install paths.

**Post-build** (`_has_install_postamble`): scan the generated `Makefile` for
a custom install target with additional dependencies (e.g.
`install :: pure_install doc_install install_sax_pureperl`). Belt-and-suspenders
for cases where `Makefile.PL` scanning is not definitive.

`needs_install_env` returns `1` for any detected case, ensuring
`Master.pm` populates `PERL5LIB` correctly before calling `install`.

## Result

**Before:**

```bash
cpm install --use-install-command -L /tmp/local XML::SAX
# FAIL install XML-SAX-1.02
# could not find ParserDetails.ini in /tmp/local/lib/perl5/XML/SAX
```

**After:**

```bash
cpm install -L /tmp/local XML::SAX   # no --use-install-command needed
# Successfully installed XML-SAX-1.02
# ParserDetails.ini written correctly to /tmp/local/lib/perl5/XML/SAX/
```

## Relation to `cpanm`

`cpanm` handles both of these correctly:

- It always runs `make install` (so postambles fire)
- It sets `PERL5LIB` to include the install target before running `make install`

This patch brings `cpm`'s behavior in line with `cpanm` for these cases, while
preserving `cpm`'s fast blib-copy path for the majority of distributions that
have no postamble.

## Files Changed

- `lib/App/cpm/Builder/Base.pm` — `_env_perl5lib` and `_set_env` updated
- `lib/App/cpm/Builder/EUMM.pm` — postamble detection, `INSTALL_BASE` handling,
  `needs_install_env` and `install` updated