### PR TITLE
Write decompressed archives in binary mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for App-cpm
 
+{{$NEXT}}
+        - Write gunzip/bunzip2 output in binary mode on Windows, where older IO::Uncompress
+          versions may otherwise corrupt decompressed tar archives with text-mode output (#304)
+
 v1.1.1  2026-05-24 13:27:13 JST
         - Use GitHub Artifact Attestations and add "ARTIFACT ATTESTATIONS" section to pod
 

--- a/lib/App/cpm/Util.pm
+++ b/lib/App/cpm/Util.pm
@@ -53,7 +53,7 @@ sub terminal_width () {
 }
 
 sub gunzip ($from, $to) {
-    my $ok = IO::Uncompress::Gunzip::gunzip($from, $to);
+    my $ok = IO::Uncompress::Gunzip::gunzip($from, $to, BinModeOut => 1);
     if ($ok) {
         return (1, undef);
     }
@@ -62,7 +62,7 @@ sub gunzip ($from, $to) {
 }
 
 sub bunzip2 ($from, $to) {
-    my $ok = IO::Uncompress::Bunzip2::bunzip2($from, $to);
+    my $ok = IO::Uncompress::Bunzip2::bunzip2($from, $to, BinModeOut => 1);
     if ($ok) {
         return (1, undef);
     }


### PR DESCRIPTION
Older IO::Uncompress versions can write decompressed archives in text mode on Windows unless BinModeOut is set. That can corrupt the temporary plain tar files used by cpm's bad-tar workaround, causing Windows bsdtar to report bad header checksums.

This makes cpm request binary output when decompressing gzip and bzip2 archives.

Fix #304