### PR TITLE
support --experimental-config option

### DIFF
--- a/META.json
+++ b/META.json
@@ -52,6 +52,7 @@
             "Parallel::Pipes::App" : "v1.0.0",
             "Parse::LocalDistribution" : "0.20",
             "Proc::ForkSafe" : "v1.0.0",
+            "YAML::PP" : "0",
             "perl" : "v5.24.0"
          }
       }

--- a/lib/App/cpm/Builder/EUMM.pm
+++ b/lib/App/cpm/Builder/EUMM.pm
@@ -18,12 +18,14 @@ sub configure ($self, $ctx, $dependency_libs, $dependency_paths) {
     push @cmd, "INSTALL_BASE=$self->{install_base}" if $self->{use_install_command} && $self->{install_base};
     push @cmd, qw(INSTALLMAN1DIR=none INSTALLMAN3DIR=none) if $self->{need_noman_argv};
     push @cmd, 'PUREPERL_ONLY=1' if $self->{pureperl_only};
-    push @cmd, $self->{argv}->@* if $self->{argv}->@*;
+    push @cmd, $self->{configure_args}->@* if $self->{configure_args};
     $self->run_configure($ctx, \@cmd, $dependency_libs, $dependency_paths) && -f 'Makefile';
 }
 
 sub build ($self, $ctx, $dependency_libs, $dependency_paths) {
-    my $ok = $self->run_build($ctx, [ $ctx->{make} ], $dependency_libs, $dependency_paths);
+    my @cmd = ($ctx->{make});
+    push @cmd, $self->{build_args}->@* if $self->{build_args};
+    my $ok = $self->run_build($ctx, \@cmd, $dependency_libs, $dependency_paths);
     return if !$ok;
     $self->_prepare_paths_cache;
     $self->_write_blib_meta($ctx);
@@ -31,7 +33,9 @@ sub build ($self, $ctx, $dependency_libs, $dependency_paths) {
 }
 
 sub test ($self, $ctx, $dependency_libs, $dependency_paths) {
-    $self->run_test($ctx, [ $ctx->{make}, "test" ], $dependency_libs, $dependency_paths);
+    my @cmd = ($ctx->{make}, "test");
+    push @cmd, $self->{test_args}->@* if $self->{test_args};
+    $self->run_test($ctx, \@cmd, $dependency_libs, $dependency_paths);
 }
 
 sub install ($self, $ctx, $dependency_libs = [], $dependency_paths = []) {

--- a/lib/App/cpm/Builder/MB.pm
+++ b/lib/App/cpm/Builder/MB.pm
@@ -14,12 +14,14 @@ sub configure ($self, $ctx, $dependency_libs, $dependency_paths) {
     push @cmd, "--install_base", $self->{install_base} if $self->{use_install_command} && $self->{install_base};
     push @cmd, qw(--config installman1dir= --config installsiteman1dir= --config installman3dir= --config installsiteman3dir=) if $self->{need_noman_argv};
     push @cmd, '--pureperl-only' if $self->{pureperl_only};
-    push @cmd, $self->{argv}->@* if $self->{argv}->@*;
+    push @cmd, $self->{configure_args}->@* if $self->{configure_args};
     $self->run_configure($ctx, \@cmd, $dependency_libs, $dependency_paths) && -f 'Build';
 }
 
 sub build ($self, $ctx, $dependency_libs, $dependency_paths) {
-    my $ok = $self->run_build($ctx, [ $ctx->{perl}, "./Build" ], $dependency_libs, $dependency_paths);
+    my @cmd = ($ctx->{perl}, "./Build");
+    push @cmd, $self->{build_args}->@* if $self->{build_args};
+    my $ok = $self->run_build($ctx, \@cmd, $dependency_libs, $dependency_paths);
     return if !$ok;
     $self->_prepare_paths_cache;
     $self->_write_blib_meta($ctx);
@@ -27,7 +29,9 @@ sub build ($self, $ctx, $dependency_libs, $dependency_paths) {
 }
 
 sub test ($self, $ctx, $dependency_libs, $dependency_paths) {
-    $self->run_test($ctx, [ $ctx->{perl}, "./Build", "test" ], $dependency_libs, $dependency_paths);
+    my @cmd = ($ctx->{perl}, "./Build", "test");
+    push @cmd, $self->{test_args}->@* if $self->{test_args};
+    $self->run_test($ctx, \@cmd, $dependency_libs, $dependency_paths);
 }
 
 sub install ($self, $ctx, $dependency_libs = [], $dependency_paths = []) {

--- a/lib/App/cpm/CLI.pm
+++ b/lib/App/cpm/CLI.pm
@@ -61,6 +61,7 @@ sub new ($class, %argv) {
         use_install_command => 0,
         default_resolvers => 1,
         report_perl_version => !$class->maybe_ci,
+        config_path => undef,
         %argv
     }, $class;
 }
@@ -191,6 +192,7 @@ sub parse_options ($self, @argv) {
         (map $with_phase_option->($_), @TOP_LEVEL_PHASE),
         "feature=s@" => \@feature,
         "show-build-log-on-failure" => \($self->{show_build_log_on_failure}),
+        "experimental-config=s" => \($self->{config_path}),
     or return 0;
 
     $self->{local_lib} = maybe_abs($self->{local_lib}, $self->{cwd}) if !$self->{global};
@@ -344,6 +346,7 @@ sub cmd_install ($self) {
     $ctx->log("Running cpm $App::cpm::VERSION$trial ($0) on perl $Config{version} built for $Config{archname} ($^X)");
     $ctx->log("This is a self-contained version, $App::cpm::GIT_DESCRIBE ($App::cpm::GIT_URL)") if $App::cpm::GIT_DESCRIBE;
     $ctx->log("Command line arguments are: @ARGV");
+    $ctx->log("Experimental config file path is $self->{config_path}") if $self->{config_path};
     $ctx->log("Work directory is $work_dir");
 
     $ctx->log("You have make $ctx->{make}") if $ctx->{make};
@@ -395,6 +398,7 @@ sub cmd_install ($self) {
         implicit_install_base => $implicit_install_base,
         eumm_argv => $eumm_argv,
         mb_argv => $mb_argv,
+        config_path => $self->{config_path},
     );
 
     $master->add_task($ctx, type => "resolve", final_target => 1, $_->%*) for $packages->@*;
@@ -931,6 +935,8 @@ Options:
         shortcut for --with-requires, --with-recommends, --with-suggests,
         --with-configure, --with-build, --with-test, --with-runtime and --with-develop
         you can also use --top-level-phase/--top-level-relationship instead
+      --experimental-config=path
+        load distribution-specific installation settings from a YAML file (experimental)
 EOF
 
 sub cmd_help ($self) {

--- a/lib/App/cpm/Worker/Installer.pm
+++ b/lib/App/cpm/Worker/Installer.pm
@@ -88,7 +88,11 @@ sub new ($class, $ctx, %argv) {
 
     my $need_noman_argv = !$argv{man_pages} &&
         ($Config{installman1dir} || $Config{installsiteman1dir} || $Config{installman3dir} || $Config{installsiteman3dir});
-    my $custom = App::cpm::Worker::Installer::Custom->new;
+    my $custom = App::cpm::Worker::Installer::Custom->default;
+    if (my $path = $argv{config_path}) {
+        my $c = App::cpm::Worker::Installer::Custom->new_from_file($path);
+        $custom = $custom->merge($c);
+    }
     bless {
         %argv,
         need_noman_argv => $need_noman_argv,
@@ -359,6 +363,11 @@ sub configure_builder ($self, $ctx, $task) {
         my ($class, $argv) = $candidate->@*;
         next if !$class->supports($meta);
 
+        my @configure_args = (
+            ( $argv ? $argv->@* : () ),
+            ( $config->{configure_args} ? $config->{configure_args}->@* : () ),
+        );
+
         my $builder = $class->new(
             meta => $meta,
             directory => $dir,
@@ -372,10 +381,12 @@ sub configure_builder ($self, $ctx, $task) {
             man_pages => $self->{man_pages},
             pureperl_only => $self->{pureperl_only},
             use_install_command => exists $config->{use_install_command} ? $config->{use_install_command} : $self->{use_install_command},
-            argv => $argv,
             configure_timeout => $self->{configure_timeout},
             build_timeout => $self->{build_timeout},
             test_timeout => $self->{test_timeout},
+            configure_args => (@configure_args ? \@configure_args : undef),
+            build_args => $config->{build_args},
+            test_args => $config->{test_args},
         );
 
         my $ok = $builder->configure($ctx, $dependency_libs, $dependency_paths);

--- a/lib/App/cpm/Worker/Installer/Custom.pm
+++ b/lib/App/cpm/Worker/Installer/Custom.pm
@@ -3,27 +3,45 @@ use v5.24;
 use warnings;
 use experimental qw(lexical_subs signatures);
 
-my @CUSTOM = (
-    {
-        match => qr{/G/GR/GRANTM/XML-SAX-[\d.]+\.tar\.gz$},
-        config => {
-            prebuilt => 0,
-            use_install_command => 1,
-        },
-    },
-);
+use YAML::PP ();
 
-sub new ($class) {
-    bless {}, $class;
+sub new ($class, %argv) {
+    bless { custom => [], %argv }, $class;
+}
+
+sub new_from_file ($class, $path) {
+    my ($data) = YAML::PP->new->load_file($path);
+    my @custom = $data->{distribution_custom} ? $data->{distribution_custom}->@* : ();
+    for my $c (@custom) {
+        $c->{match} = qr/$c->{match}/;
+    }
+    $class->new(custom => \@custom);
 }
 
 sub config ($self, $dist_uri) {
-    for my $c (@CUSTOM) {
+    for my $c ($self->{custom}->@*) {
         if ($dist_uri =~ $c->{match}) {
             return $c->{config};
         }
     }
     return;
+}
+
+sub merge ($self, $other) {
+    my $class = ref $self;
+    $class->new(custom => [ $self->{custom}->@*, $other->{custom}->@* ]);
+}
+
+sub default ($class) {
+    $class->new(custom => [
+        {
+            match => qr{/G/GR/GRANTM/XML-SAX-[\d.]+\.tar\.gz$},
+            config => {
+                prebuilt => 0,
+                use_install_command => 1,
+            },
+        },
+    ]);
 }
 
 1;


### PR DESCRIPTION
This adds an experimental `--experimental-config` option for applying distribution-specific installation settings.

For example, a config can match CryptX and pass `-j8` to `make`, allowing its native code to build in parallel:

```yaml
# cpm-config.yaml
distribution_custom:
  - match: '/M/MI/MIK/CryptX-[0-9_.]+\.tar\.gz$'
    config:
      build_args: ["-j8"]

```
```
cpm install --experimental-config cpm-config.yaml CryptX
```